### PR TITLE
fix: encode department IDs

### DIFF
--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -11,8 +11,8 @@ import type { MockRegistration, Registration } from "@/lib/types";
 
 const departmentOptions = [
   "Filia w Legnicy [FLG]",
-  "Studium Języków Obcych [PRD/S1]",
-  "Studium Wychowania Fizycznego i Sportu [PRD/S3]",
+  "Studium Języków Obcych [PRK24/S1]",
+  "Studium Wychowania Fizycznego i Sportu [PRK24/S3]",
   "Politechnika Wrocławska [PWR]",
   "Wydział Architektury [W1]",
   "Wydział Mechaniczny [W10]",

--- a/src/pages/createplan/[id].tsx
+++ b/src/pages/createplan/[id].tsx
@@ -94,7 +94,7 @@ const CreatePlan = ({
       throw new Error(`Invalid faculty name: ${facultyName}`);
     }
 
-    const res = await fetch(`/api/data/${facultyID}`);
+    const res = await fetch(`/api/data/${encodeURIComponent(facultyID)}`);
     if (!res.ok) {
       throw new Error("Failed to fetch data");
     }


### PR DESCRIPTION
Department IDs may contain slashes, which need to be encoded when fetching data from the API