### PR TITLE
fix: delete unused code

### DIFF
--- a/backend/app/controllers/schedules_controller.ts
+++ b/backend/app/controllers/schedules_controller.ts
@@ -52,9 +52,6 @@ export default class SchedulesController {
       .preload('courses') // Preload courses (grupy powiązane z kursami zostaną załadowane osobno)
       .firstOrFail()
 
-    // Pobranie grup powiązanych z harmonogramem (schedule_groups)
-    const relatedGroups = await schedule.related('groups').query()
-
     // Pobranie grup powiązanych z kursami z uwzględnieniem schedule_id
     const courseGroups = await schedule
       .related('courses')


### PR DESCRIPTION
This pull request includes a change to the `SchedulesController` class in the `backend/app/controllers/schedules_controller.ts` file. The change removes the unnecessary query to fetch related groups, thereby simplifying the code and improving performance.

Codebase simplification:

* [`backend/app/controllers/schedules_controller.ts`](diffhunk://#diff-ae488a05ca0be6532467a3a0b2eb4ce34b6bf029a9141ef8116ba93dc4da85b4L55-L57): Removed the query to fetch related groups (`relatedGroups`) that was not needed for the subsequent operations.