### PR TITLE
feat: updatedAt update option

### DIFF
--- a/backend/app/controllers/schedules_controller.ts
+++ b/backend/app/controllers/schedules_controller.ts
@@ -1,6 +1,7 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import Schedule from '#models/schedule'
 import { createScheduleValidator, updateScheduleValidator } from '#validators/schedule'
+import { DateTime } from 'luxon'
 
 export default class SchedulesController {
   /**
@@ -131,6 +132,12 @@ export default class SchedulesController {
       } else {
         await currSchedule.related('courses').sync(payload.courses.map((group) => group.id))
       }
+    }
+
+    if (payload.updatedAt) {
+      currSchedule.updatedAt = DateTime.fromJSDate(payload.updatedAt)
+    } else {
+      currSchedule.updatedAt = DateTime.now()
     }
 
     await currSchedule.save()

--- a/backend/app/controllers/schedules_controller.ts
+++ b/backend/app/controllers/schedules_controller.ts
@@ -136,8 +136,6 @@ export default class SchedulesController {
 
     if (payload.updatedAt) {
       currSchedule.updatedAt = DateTime.fromJSDate(payload.updatedAt)
-    } else {
-      currSchedule.updatedAt = DateTime.now()
     }
 
     await currSchedule.save()

--- a/backend/app/validators/schedule.ts
+++ b/backend/app/validators/schedule.ts
@@ -30,5 +30,6 @@ export const updateScheduleValidator = vine.compile(
         })
       )
       .optional(),
+    updatedAt: vine.date().optional(),
   })
 )


### PR DESCRIPTION
This pull request introduces enhancements to the schedule updating process in the `SchedulesController`. The changes ensure that the `updatedAt` field is properly managed when updating a schedule.

Key changes include:

* **Importing necessary modules:**
  * Added import for `DateTime` from `luxon` in `backend/app/controllers/schedules_controller.ts` to handle date and time operations.

* **Updating schedule logic:**
  * Modified the `update` method in `SchedulesController` to set the `updatedAt` field based on the payload or default to the current time if not provided.

* **Validation changes:**
  * Added `updatedAt` as an optional field in the `updateScheduleValidator` in `backend/app/validators/schedule.ts` to ensure it can be processed during validation.