### PR TITLE
fix: auth tokens hot fix

### DIFF
--- a/frontend/src/lib/auth/index.ts
+++ b/frontend/src/lib/auth/index.ts
@@ -142,7 +142,7 @@ export const auth = async (tokens?: {
     }
     const setCookieHeaders = response.headers.getSetCookie();
     setCookieHeaders.forEach((cookie) => {
-      const preparedCookie = cookie.replace(";", "");
+      const preparedCookie = cookie.split(";")[0];
       const [name, value] = preparedCookie.split("=");
       cookies.set({
         name,


### PR DESCRIPTION
This pull request includes a small but important change to the `frontend/src/lib/auth/index.ts` file. The change ensures that only the first part of the cookie string is used, which improves the handling of cookies.

* [`frontend/src/lib/auth/index.ts`](diffhunk://#diff-57e6f0f934dbe964fed914cc9e285a1a6ee1f5e6c66ceb2d4cde7f938dbf76b6L145-R145): Modified the `preparedCookie` variable to use the first part of the cookie string by splitting it at the semicolon.