### PR TITLE
fix: hot fix in createdAt (maybe undefined)

### DIFF
--- a/frontend/src/components/PlanItem.tsx
+++ b/frontend/src/components/PlanItem.tsx
@@ -108,6 +108,7 @@ export const PlanItem = ({
       id: uuid,
       onlineId,
       name,
+      createdAt: new Date(),
     });
 
     setTimeout(() => {
@@ -139,7 +140,9 @@ export const PlanItem = ({
         </CardTitle>
         <CardDescription>
           {format(
-            onlineOnly ? updatedAt : plan.createdAt,
+            onlineOnly
+              ? updatedAt
+              : ((plan.createdAt as Date | undefined) ?? new Date()),
             "dd.MM.yyyy - HH:mm",
           )}
         </CardDescription>


### PR DESCRIPTION
byl blad taki, ze jesli tworzy sie plan z planu online to moze stworzyc sie plan bez createdAt ktore jest uzupelniane dopiero pozniej, fixniete ale aby zachowac kompatybilnosc wsteczna z planami bez createdat dodalem pokazywanie aktulanej daty