### PR TITLE
fix: small changes in scraper to delete removed groups

### DIFF
--- a/backend/commands/scraper.ts
+++ b/backend/commands/scraper.ts
@@ -156,6 +156,7 @@ export default class Scraper extends BaseCommand {
       }),
     );
     this.logger.log("Scraping groups details");
+    const processedGroupIds: number[] = [];
     for (const registration of registrations) {
       for (const course of registration.courses) {
         const detailsUrls = (await Promise.all(
@@ -222,11 +223,14 @@ export default class Scraper extends BaseCommand {
               },
             );
 
+            processedGroupIds.push(group.id);
+
             await group.related("lecturers").sync(lecturerIds);
           }),
         );
       }
     }
+    await Group.query().whereNotIn("id", processedGroupIds).delete();
     this.logger.log("Groups details scraped");
   }
 }


### PR DESCRIPTION
fix który usuwa usunięte groupy ze strony usosa. Wczesniej nie usuwalo dlatego np po poprawce marcina stało w naszym planie Dwa wyklady projektowania oprogramowania jeden z W jeden z P