### PR TITLE
feat: mobile version for settings page

### DIFF
--- a/frontend/src/app/plans/_components/settings-sidebar.tsx
+++ b/frontend/src/app/plans/_components/settings-sidebar.tsx
@@ -23,10 +23,7 @@ export function SidebarSettings({
 
   return (
     <nav
-      className={cn(
-        "flex space-x-2 lg:flex-col lg:space-x-0 lg:space-y-1",
-        className,
-      )}
+      className={cn("flex flex-col space-x-0 lg:space-y-1", className)}
       {...props}
     >
       {items.map((item) => (

--- a/frontend/src/app/plans/account/layout.tsx
+++ b/frontend/src/app/plans/account/layout.tsx
@@ -43,7 +43,7 @@ export default async function SettingsLayout({
 
   return (
     <div className="w-full pb-10">
-      <div className="container mx-auto flex h-full min-h-screen flex-col space-y-6 p-10 pb-0">
+      <div className="container mx-auto flex h-full min-h-screen flex-col space-y-6 p-4 pb-0 md:p-10">
         <div className="space-y-0.5">
           <h2 className="text-2xl font-bold tracking-tight">Ustawienia</h2>
           <p className="text-muted-foreground">

--- a/frontend/src/app/plans/account/page.tsx
+++ b/frontend/src/app/plans/account/page.tsx
@@ -37,7 +37,7 @@ export default async function ProfilePage() {
         </p>
       </div>
       <Separator />
-      <div className="flex items-start gap-4 rounded-md border p-5">
+      <div className="flex flex-col items-start gap-4 rounded-md border p-5 md:flex-row">
         <div className="size-[51px] min-w-[51px] rounded-full border">
           <Image
             src={profile.photo_urls["50x50"]}


### PR DESCRIPTION
This pull request includes several changes to the layout and styling of the settings and profile pages in the frontend. The main focus is on improving the responsiveness and consistency of the UI elements.

### Improvements to layout and styling:

* [`frontend/src/app/plans/_components/settings-sidebar.tsx`](diffhunk://#diff-848e03c48f11ef418eef7231741754f1d1d66d4baa90d9b73801743d3e7d58e5L26-R26): Simplified the class names for the sidebar navigation to ensure a consistent flex column layout.
* [`frontend/src/app/plans/account/layout.tsx`](diffhunk://#diff-97c72c678563a4fc46016c490e906e12917d9a1f34430aeb24be90de958f86b9L46-R46): Adjusted the padding for the settings layout to be more responsive, especially on smaller screens.
* [`frontend/src/app/plans/account/page.tsx`](diffhunk://#diff-ee9fb62beb7086d589929383e03e137cd1b295b8c9d708e109a4180fabeb7190L40-R40): Modified the profile page layout to switch between column and row flex directions based on screen size, improving the layout on smaller devices.