### PR TITLE
fix: switch theme on mobile

### DIFF
--- a/frontend/src/app/(homepage)/_components/navbar.tsx
+++ b/frontend/src/app/(homepage)/_components/navbar.tsx
@@ -85,7 +85,8 @@ export function Navbar() {
         </nav>
 
         {/* Mobile Menu Icon */}
-        <div className="flex h-20 items-center md:hidden">
+        <div className="flex h-20 items-center gap-1 md:hidden">
+          <ModeToggle />
           <Button onClick={toggleMenu} size={"icon"} variant={"outline"}>
             {isMenuOpen ? (
               <Icons.X className="!size-6" />


### PR DESCRIPTION
This pull request includes a small change to the `frontend/src/app/(homepage)/_components/navbar.tsx` file. The change adds a `ModeToggle` component and introduces a `gap-1` class to the mobile menu icon container for better spacing.

* [`frontend/src/app/(homepage)/_components/navbar.tsx`](diffhunk://#diff-9c9ba69b5f4440569d1f12257cb29139daef7c9b9acf40c0ab64109ded1e74ebL88-R89): Added `ModeToggle` component and `gap-1` class to the mobile menu icon container for improved spacing.