### PR TITLE
feat: hide days on preview settings & ui bug fixes

### DIFF
--- a/frontend/src/app/plans/_components/download-button.tsx
+++ b/frontend/src/app/plans/_components/download-button.tsx
@@ -10,9 +10,11 @@ import type { PlanState } from "@/types";
 export function DownloadPlanButton({
   captureRef,
   plan,
+  hideDays,
 }: {
   captureRef: React.RefObject<HTMLDivElement>;
   plan: PlanState;
+  hideDays: boolean;
 }) {
   const [loading, setLoading] = React.useState(false);
 
@@ -28,6 +30,10 @@ export function DownloadPlanButton({
       link.download = `${plan.name}.png`;
       link.href = dataUrl;
       link.click();
+
+      void window.umami?.track("Download plan", {
+        withHiddenDays: hideDays.toString(),
+      });
     } catch (error: unknown) {
       console.error(error);
     } finally {

--- a/frontend/src/app/plans/_components/download-button.tsx
+++ b/frontend/src/app/plans/_components/download-button.tsx
@@ -39,7 +39,7 @@ export function DownloadPlanButton({
     } finally {
       setLoading(false);
     }
-  }, [captureRef, plan.name]);
+  }, [captureRef, hideDays, plan.name]);
 
   return (
     <Button

--- a/frontend/src/app/plans/edit/[id]/_components/hide-days-settings.tsx
+++ b/frontend/src/app/plans/edit/[id]/_components/hide-days-settings.tsx
@@ -1,0 +1,26 @@
+import type { Dispatch, SetStateAction } from "react";
+import React from "react";
+
+import { Switch } from "@/components/ui/switch";
+
+export function HideDaysSettings({
+  hideDays,
+  setHideDays,
+}: {
+  hideDays: boolean;
+  setHideDays: Dispatch<SetStateAction<boolean>>;
+}) {
+  const handleChange = (checked: boolean) => {
+    setHideDays(checked);
+    localStorage.setItem("hideDays", JSON.stringify(checked));
+    void window.umami?.track("Set hide days", {
+      checked: checked.toString(),
+    });
+  };
+  return (
+    <div className="flex items-center justify-between gap-4 p-4">
+      <h3>Ukryj dni bez zajęć</h3>
+      <Switch checked={hideDays} onCheckedChange={handleChange} />
+    </div>
+  );
+}

--- a/frontend/src/app/plans/edit/[id]/page.client.tsx
+++ b/frontend/src/app/plans/edit/[id]/page.client.tsx
@@ -50,6 +50,7 @@ import type { CourseType, FacultyType } from "@/types";
 
 import { DownloadPlanButton } from "../../_components/download-button";
 import { SharePlanButton } from "../../_components/share-plan-button";
+import { HideDaysSettings } from "./_components/hide-days-settings";
 import { OfflineAlert } from "./_components/offline-alert";
 import { SyncErrorAlert } from "./_components/sync-error-alert";
 import { SyncedButton } from "./_components/synced-button";
@@ -66,6 +67,7 @@ export function CreateNewPlanPage({
   const [faculty, setFaculty] = useState<string | null>(null);
   const { user } = useSession();
   const { isDialogOpen, setIsDialogOpen } = useShare();
+  const [hideDays, setHideDays] = useState(false);
 
   const firstTime = useRef(true);
   const captureRef = useRef<HTMLDivElement>(null);
@@ -219,6 +221,11 @@ export function CreateNewPlanPage({
   useEffect(() => {
     if (plan.onlineId === null && firstTime.current) {
       void handleCreateOnlinePlan();
+
+      const hideDaysSettings = localStorage.getItem("hideDays");
+      if (hideDaysSettings === "true") {
+        setHideDays(true);
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [plan.onlineId]);
@@ -517,7 +524,8 @@ export function CreateNewPlanPage({
               zobaczyć lub pobrać w formacie .png
             </DialogDescription>
           </DialogHeader>
-          <div className="relative h-full max-h-[700px] overflow-y-auto">
+          <div className="relative h-full max-h-[800px] overflow-y-auto">
+            <HideDaysSettings hideDays={hideDays} setHideDays={setHideDays} />
             <div
               ref={captureRef}
               className="relative flex flex-col gap-2 bg-background p-1"
@@ -528,20 +536,23 @@ export function CreateNewPlanPage({
                 { day: Day.WEDNESDAY, label: "Środa" },
                 { day: Day.THURSDAY, label: "Czwartek" },
                 { day: Day.FRIDAY, label: "Piątek" },
-              ].map(({ day, label }) => (
-                <ClassSchedule
-                  key={day}
-                  day={label}
-                  isReadonly={true}
-                  selectedGroups={[]}
-                  groups={plan.allGroups.filter(
-                    (g) => g.day === day && g.isChecked,
-                  )}
-                  onSelectGroup={(groupdId) => {
-                    plan.selectGroup(groupdId);
-                  }}
-                />
-              ))}
+              ].map(
+                ({ day, label }) =>
+                  (!hideDays || plan.allGroups.some((g) => g.day === day)) && (
+                    <ClassSchedule
+                      key={day}
+                      day={label}
+                      isReadonly={true}
+                      selectedGroups={[]}
+                      groups={plan.allGroups.filter(
+                        (g) => g.day === day && g.isChecked,
+                      )}
+                      onSelectGroup={(groupdId) => {
+                        plan.selectGroup(groupdId);
+                      }}
+                    />
+                  ),
+              )}
               {[
                 { day: Day.SATURDAY, label: "Sobota" },
                 { day: Day.SUNDAY, label: "Niedziela" },
@@ -590,7 +601,11 @@ export function CreateNewPlanPage({
               exit={{ opacity: 0, y: -30 }}
               className="absolute bottom-6 right-8 z-20 flex flex-col items-center gap-2 rounded-xl border bg-background/50 px-3 py-2 shadow-md backdrop-blur-[12px] md:flex-row md:rounded-full"
             >
-              <DownloadPlanButton plan={plan} captureRef={captureRef} />
+              <DownloadPlanButton
+                plan={plan}
+                captureRef={captureRef}
+                hideDays={hideDays}
+              />
 
               <SharePlanButton plan={plan} />
             </motion.div>

--- a/frontend/src/app/plans/preview/[id]/page.client.tsx
+++ b/frontend/src/app/plans/preview/[id]/page.client.tsx
@@ -25,7 +25,7 @@ export function SharePlanPage({ plan }: { plan: SharedPlan["plan"] }) {
   const copyPlan = () => {
     const newPlan = {
       id: uuid,
-      courses: plan.courses,
+      ...plan,
     };
 
     void window.umami?.track("Create plan", {
@@ -35,7 +35,7 @@ export function SharePlanPage({ plan }: { plan: SharedPlan["plan"] }) {
     setPlans([...plans, newPlan]);
     setPlanToCopy({
       ...planToCopy,
-      courses: plan.courses,
+      ...plan,
     });
 
     setTimeout(() => {
@@ -44,8 +44,8 @@ export function SharePlanPage({ plan }: { plan: SharedPlan["plan"] }) {
   };
 
   return (
-    <div className="flex grow flex-col">
-      <div className="container mx-auto flex items-center justify-between gap-4 px-14 py-4">
+    <div className="flex w-full grow flex-col overflow-x-auto">
+      <div className="container mx-auto flex items-center justify-between gap-4 px-4 py-4 md:px-14">
         <h1 className="text-xl font-semibold">{plan.name}</h1>
 
         <div className="flex items-center gap-1">
@@ -62,7 +62,7 @@ export function SharePlanPage({ plan }: { plan: SharedPlan["plan"] }) {
 
       <div
         ref={captureRef}
-        className="flex flex-col gap-2 overflow-auto bg-background p-1 scrollbar-thin scrollbar-track-sky-300 scrollbar-thumb-sky-900"
+        className="flex flex-col gap-2 overflow-auto bg-background p-1 scrollbar-thin"
       >
         {[
           { day: Day.MONDAY, label: "Poniedziałek" },


### PR DESCRIPTION
This pull request introduces a new feature to hide days without classes in the plan view and includes several related changes across multiple files. The most important changes are listed below:

### New Feature: Hide Days Without Classes

* [`frontend/src/app/plans/_components/download-button.tsx`](diffhunk://#diff-8f1be84b0bcfa43ccbc10e3dae64879492b6e9bfdd7161cd6f5a1d1fe7d42cbbR13-R17): Added a new `hideDays` prop to the `DownloadPlanButton` component and updated the download tracking to include the `hideDays` state. [[1]](diffhunk://#diff-8f1be84b0bcfa43ccbc10e3dae64879492b6e9bfdd7161cd6f5a1d1fe7d42cbbR13-R17) [[2]](diffhunk://#diff-8f1be84b0bcfa43ccbc10e3dae64879492b6e9bfdd7161cd6f5a1d1fe7d42cbbR33-R42)
* `frontend/src/app/plans/edit/[id]/_components/hide-days-settings.tsx`: Created a new `HideDaysSettings` component that includes a switch to toggle the `hideDays` state and tracks the setting change. ([frontend/src/app/plans/edit/[id]/_components/hide-days-settings.tsxR1-R26](diffhunk://#diff-1d7a39285fab0886fe3c8b2d55a94de356ae7f3bd0527cd5a5593101c9bd2f92R1-R26))
* `frontend/src/app/plans/edit/[id]/page.client.tsx`: Integrated the `HideDaysSettings` component into the plan editing page, added state management for `hideDays`, and ensured the setting is persisted in `localStorage`. Also, updated the rendering logic to conditionally hide days without classes based on the `hideDays` state. ([frontend/src/app/plans/edit/[id]/page.client.tsxR53](diffhunk://#diff-14dcdc3ba4c06f83798f84fc7b67821bf00cca4f895ae80904dc4adc2ad65909R53), [frontend/src/app/plans/edit/[id]/page.client.tsxR70](diffhunk://#diff-14dcdc3ba4c06f83798f84fc7b67821bf00cca4f895ae80904dc4adc2ad65909R70), [frontend/src/app/plans/edit/[id]/page.client.tsxR224-R228](diffhunk://#diff-14dcdc3ba4c06f83798f84fc7b67821bf00cca4f895ae80904dc4adc2ad65909R224-R228), [frontend/src/app/plans/edit/[id]/page.client.tsxL520-R528](diffhunk://#diff-14dcdc3ba4c06f83798f84fc7b67821bf00cca4f895ae80904dc4adc2ad65909L520-R528), [frontend/src/app/plans/edit/[id]/page.client.tsxL531-R541](diffhunk://#diff-14dcdc3ba4c06f83798f84fc7b67821bf00cca4f895ae80904dc4adc2ad65909L531-R541), [frontend/src/app/plans/edit/[id]/page.client.tsxL593-R608](diffhunk://#diff-14dcdc3ba4c06f83798f84fc7b67821bf00cca4f895ae80904dc4adc2ad65909L593-R608))

### Code Improvements

* `frontend/src/app/plans/preview/[id]/page.client.tsx`: Simplified the plan copying logic by spreading the `plan` object, and improved the layout and styling of the `SharePlanPage` component. ([frontend/src/app/plans/preview/[id]/page.client.tsxL28-R28](diffhunk://#diff-6f328dfd537318bca8d2f1f1532128d2a228e34c0d8b3772c3d325c27422a697L28-R28), [frontend/src/app/plans/preview/[id]/page.client.tsxL38-R38](diffhunk://#diff-6f328dfd537318bca8d2f1f1532128d2a228e34c0d8b3772c3d325c27422a697L38-R38), [frontend/src/app/plans/preview/[id]/page.client.tsxL47-R48](diffhunk://#diff-6f328dfd537318bca8d2f1f1532128d2a228e34c0d8b3772c3d325c27422a697L47-R48), [frontend/src/app/plans/preview/[id]/page.client.tsxL65-R65](diffhunk://#diff-6f328dfd537318bca8d2f1f1532128d2a228e34c0d8b3772c3d325c27422a697L65-R65))