### PR TITLE
refactor(scraper): fix, optimize, refactor

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.12.2-alpine3.18 AS base
+FROM node:22.14.0-alpine3.21 AS base
 
 # All deps stage
 FROM base AS deps

--- a/backend/app/utils/arrays.ts
+++ b/backend/app/utils/arrays.ts
@@ -1,0 +1,20 @@
+export function chunkArray<T>(array: T[], chunkSize: number): T[][] {
+  const result = [];
+  const input = Array.from(array);
+  while (input.length > 0) {
+    result.push(input.splice(0, chunkSize));
+  }
+  return result;
+}
+
+export function zip<T1, T2>(a1: T1[], a2: T2[]): [T1, T2][] {
+  const array1 = Array.from(a1);
+  const array2 = Array.from(a2);
+  const result: [T1, T2][] = [];
+  while (array1.length > 0 && array2.length > 0) {
+    const el1 = array1.shift() as T1;
+    const el2 = array2.shift() as T2;
+    result.push([el1, el2]);
+  }
+  return result;
+}

--- a/backend/app/utils/semaphore.ts
+++ b/backend/app/utils/semaphore.ts
@@ -1,0 +1,49 @@
+export class Semaphore {
+  capacity: number;
+  #currentTasks: number;
+  #waitingTasks: (() => void)[];
+
+  constructor(capacity: number) {
+    this.capacity = capacity;
+    this.#currentTasks = 0;
+    this.#waitingTasks = [];
+  }
+
+  public get currentTasks(): number {
+    return this.#currentTasks;
+  }
+
+  public async runTask<T>(task: () => Promise<T>): Promise<T> {
+    // acquire the semaphore
+    await this.acquire();
+    try {
+      // execute the task
+      return await task();
+    } finally {
+      // don't forget to release
+      this.release();
+    }
+  }
+
+  private acquire(): Promise<void> {
+    // if we're under capacity, bump the count and resolve immediately
+    if (this.capacity > this.#currentTasks) {
+      this.#currentTasks += 1;
+      return Promise.resolve();
+    }
+    // otherwise add ourselves to the queue
+    return new Promise((resolve) => this.#waitingTasks.push(resolve));
+  }
+
+  private release() {
+    // try waking up the next task
+    const nextTask = this.#waitingTasks.shift();
+    if (nextTask === undefined) {
+      // no task in queue, decrement task count
+      this.#currentTasks -= 1;
+    } else {
+      // wake up the task
+      nextTask();
+    }
+  }
+}

--- a/backend/commands/scraper.ts
+++ b/backend/commands/scraper.ts
@@ -1,9 +1,18 @@
-import { BaseCommand } from "@adonisjs/core/ace";
+import { TaskCallback } from "@poppinss/cliui/types";
+import assert from "node:assert";
+
+import { BaseCommand, flags } from "@adonisjs/core/ace";
 import type { CommandOptions } from "@adonisjs/core/types/ace";
 
+import Course from "#models/course";
+import Department from "#models/department";
+import Group from "#models/group";
+import GroupArchive from "#models/group_archive";
 import Lecturer from "#models/lecturer";
+import Registration from "#models/registration";
 
 import {
+  ScrapedDepartment,
   scrapCourseNameGroupsUrls,
   scrapCourses,
   scrapDepartments,
@@ -24,9 +33,87 @@ function extractLastStringInBrackets(input: string): string | null {
   return lastMatch;
 }
 
+function chunkArray<T>(array: T[], chunkSize: number): T[][] {
+  const result = [];
+  const input = Array.from(array);
+  while (input.length > 0) {
+    result.push(input.splice(0, chunkSize));
+  }
+  return result;
+}
+
+function zip<T1, T2>(a1: T1[], a2: T2[]): [T1, T2][] {
+  const array1 = Array.from(a1);
+  const array2 = Array.from(a2);
+  const result: [T1, T2][] = [];
+  while (array1.length > 0 && array2.length > 0) {
+    const el1 = array1.shift() as T1;
+    const el2 = array2.shift() as T2;
+    result.push([el1, el2]);
+  }
+  return result;
+}
+
+const QUERY_CHUNK_SIZE = 4096;
+type TaskHandle = Parameters<TaskCallback>[0];
+
+class Semaphore {
+  capacity: number;
+  #currentTasks: number;
+  #waitingTasks: (() => void)[];
+
+  constructor(capacity: number) {
+    this.capacity = capacity;
+    this.#currentTasks = 0;
+    this.#waitingTasks = [];
+  }
+
+  public get currentTasks(): number {
+    return this.#currentTasks;
+  }
+
+  public async runTask<T>(task: () => Promise<T>): Promise<T> {
+    // acquire the semaphore
+    await this.acquire();
+    try {
+      // execute the task
+      return await task();
+    } finally {
+      // don't forget to release
+      this.release();
+    }
+  }
+
+  private acquire(): Promise<void> {
+    // if we're under capacity, bump the count and resolve immediately
+    if (this.capacity > this.#currentTasks) {
+      this.#currentTasks += 1;
+      return Promise.resolve();
+    }
+    // otherwise add ourselves to the queue
+    return new Promise((resolve) => this.#waitingTasks.push(resolve));
+  }
+
+  private release() {
+    // try waking up the next task
+    const nextTask = this.#waitingTasks.shift();
+    if (nextTask === undefined) {
+      // no task in queue, decrement task count
+      this.#currentTasks -= 1;
+    } else {
+      // wake up the task
+      nextTask();
+    }
+  }
+}
+
 export default class Scraper extends BaseCommand {
   static commandName = "scraper";
-  static description = "Scrap data from usos pages and insert it to database";
+  static description = "Scrape data from usos pages and insert it to database";
+
+  declare scrapingSemaphore: Semaphore;
+  declare dbSemaphore: Semaphore;
+  declare departments: ScrapedDepartment[];
 
   static options: CommandOptions = {
     startApp: true,
@@ -34,244 +121,373 @@ export default class Scraper extends BaseCommand {
     staysAlive: false,
   };
 
-  async run() {
-    const DepartmentModule = await import("#models/department");
-    const Department = DepartmentModule.default;
-    const RegistrationModule = await import("#models/registration");
-    const Registration = RegistrationModule.default;
-    const CourseModule = await import("#models/course");
-    const Course = CourseModule.default;
-    const GroupModule = await import("#models/group");
-    const Group = GroupModule.default;
-    const GroupArchiveModule = await import("#models/group_archive");
-    const GroupArchive = GroupArchiveModule.default;
+  @flags.number({
+    alias: ["max-usos"],
+    default: 32,
+  })
+  declare maxUsosRequests: number;
 
-    this.logger.log("Scraping departments");
-    const departments = await scrapDepartments();
-    if (departments === undefined) {
-      return;
-    }
+  @flags.number({
+    alias: ["max-db"],
+    default: 64,
+  })
+  declare maxDbRequests: number;
 
+  async departmentScrapeTask(task: TaskHandle) {
+    task.update("Fetching");
+    this.departments = await scrapDepartments();
+
+    task.update("Updating");
     await Promise.all(
-      departments.map((department) =>
-        Department.updateOrCreate(
-          {
-            id: extractLastStringInBrackets(department.name) ?? department.name,
-          },
-          { name: department.name, url: department.url },
+      chunkArray(this.departments, QUERY_CHUNK_SIZE).map((chunk) =>
+        this.dbSemaphore.runTask(() =>
+          Department.updateOrCreateMany(
+            "id",
+            chunk.map((department) => {
+              return {
+                id:
+                  extractLastStringInBrackets(department.name) ??
+                  department.name,
+                name: department.name,
+                url: department.url,
+              };
+            }),
+          ),
         ),
       ),
     );
-    this.logger.log("Scraping registrations");
-    const processedRegistrationIds: string[] = [];
-    const registrations = await Promise.all(
-      departments.map(async (department) => {
-        const regs = await scrapRegistrations(department.url);
-        if (regs === undefined) {
-          return [];
-        }
-        department.registrations = regs;
+  }
 
-        await Promise.all(
-          department.registrations.map(async (registration) => {
-            const updatedRegistration = await Registration.updateOrCreate(
-              {
-                id:
-                  extractLastStringInBrackets(registration.name) ??
-                  registration.name,
-              },
-              {
-                name: registration.name,
-                departmentId:
-                  extractLastStringInBrackets(department.name) ??
-                  department.name,
-                isActive: true,
-              },
-            );
-            processedRegistrationIds.push(updatedRegistration.id);
-          }),
-        );
-
-        return regs;
-      }),
-    ).then((results) => results.flat());
-
-    await Registration.query()
-      .whereNotIn("id", processedRegistrationIds)
-      .update({ isActive: false });
-    this.logger.log("Registrations scraped");
-    this.logger.log("Scraping courses urls");
-    const processedCourseIds: string[] = [];
+  async registrationScrapeTask(task: TaskHandle) {
+    task.update("Fetching");
     await Promise.all(
-      registrations.map(async (registration) => {
-        let urls;
+      this.departments.map(async (department) => {
         try {
-          urls = await scrapCourses(registration.url);
-        } catch (e: unknown) {
-          // @ts-expect-error i dont caRe
-          this.logger.logError(e);
+          department.registrations = await this.scrapingSemaphore.runTask(() =>
+            scrapRegistrations(department.url),
+          );
+        } catch (e) {
+          assert(e instanceof Error);
+          this.logger.warning(
+            `Failed to scrape registrations for '${department.name}': ${e.message}\n${e.stack}`,
+          );
         }
-        if (urls === undefined) {
-          return [];
-        }
-        registration.courses = urls.map((courseUrl) => {
-          return { url: courseUrl, courseCode: "", groups: [], name: "" };
+      }),
+    );
+
+    task.update("Updating");
+    // set all registrations to inactive
+    await Registration.query().update({ isActive: false });
+
+    // then insert just-scraped ones and set those to active
+    const toInsert = this.departments.flatMap((department) => {
+      return department.registrations.map((registration) => {
+        return {
+          id:
+            extractLastStringInBrackets(registration.name) ?? registration.name,
+          name: registration.name,
+          departmentId:
+            extractLastStringInBrackets(department.name) ?? department.name,
+          isActive: true,
+        };
+      });
+    });
+    await Promise.all(
+      chunkArray(toInsert, QUERY_CHUNK_SIZE).map((chunk) =>
+        this.dbSemaphore.runTask(() =>
+          Registration.updateOrCreateMany("id", chunk),
+        ),
+      ),
+    );
+  }
+
+  async courseUrlScrapeTask() {
+    await Promise.all(
+      this.departments.flatMap((department) => {
+        return department.registrations.map(async (registration) => {
+          let urls;
+          try {
+            urls = await this.scrapingSemaphore.runTask(() =>
+              scrapCourses(registration.url),
+            );
+          } catch (e: unknown) {
+            assert(e instanceof Error);
+            this.logger.warning(
+              `Failed to scrape course URLs for '${registration.name}': ${e.message}\n${e.stack}`,
+            );
+            return;
+          }
+          registration.courses = urls.map((courseUrl) => {
+            return { url: courseUrl, courseCode: "", groups: [], name: "" };
+          });
         });
       }),
     );
-    this.logger.log("Courses urls scraped");
-    this.logger.log("Scraping courses details");
-    for (const registration of registrations) {
-      await Promise.all(
-        registration.courses.map(async (course) => {
-          const courseCodeNameGroupsUrls = await scrapCourseNameGroupsUrls(
-            course.url,
-          );
-          if (courseCodeNameGroupsUrls === undefined) {
-            return;
-          }
-          const urls = courseCodeNameGroupsUrls.urls;
-          course.courseCode = courseCodeNameGroupsUrls.courseCode;
-          course.name = courseCodeNameGroupsUrls.courseName;
-          course.groups = urls.map((url) => {
-            return { url, groups: [] };
-          });
-          const updatedCourse = await Course.updateOrCreate(
-            {
-              id:
-                courseCodeNameGroupsUrls.courseCode +
-                (extractLastStringInBrackets(registration.name) ??
-                  registration.name),
-            },
-            {
-              name: course.name,
-              registrationId:
-                extractLastStringInBrackets(registration.name) ??
-                registration.name,
-              isActive: true,
-            },
-          );
-          processedCourseIds.push(updatedCourse.id);
-        }),
-      );
-    }
-    await Course.query()
-      .whereNotIn("id", processedCourseIds)
-      .update({ isActive: false });
-    this.logger.log("Courses details scraped");
-    this.logger.log("Synchronizing group_archive with current groups");
-    const currentGroups = await Group.all();
+  }
 
+  async courseDetailScrapeTask(task: TaskHandle) {
+    task.update("Fetching");
     await Promise.all(
-      currentGroups.map(async (group) => {
-        const groupArchive = await GroupArchive.updateOrCreate(
-          { id: group.id },
-          {
-            ...group.$attributes,
-          },
-        );
-
-        const lecturers = await group.related("lecturers").query();
-
-        await groupArchive
-          .related("lecturers")
-          .sync(lecturers.map((lecturer) => lecturer.id));
-      }),
-    );
-    this.logger.log("Scraping groups details");
-    const processedGroupIds: number[] = [];
-    for (const registration of registrations) {
-      for (const course of registration.courses) {
-        const detailsUrls = (await Promise.all(
-          course.groups.map(async (group) => {
-            return await scrapGroupsUrls(group.url);
-          }),
-        ).then((results) => results.flat())) as string[];
-
-        await Promise.all(
-          detailsUrls.map(async (url) => {
-            const details = await scrapGroupDetails(url);
-            if (details === undefined) {
+      this.departments.flatMap((department) => {
+        return department.registrations.flatMap((registration) => {
+          return registration.courses.map(async (course) => {
+            let courseDetails;
+            try {
+              courseDetails = await this.scrapingSemaphore.runTask(() =>
+                scrapCourseNameGroupsUrls(course.url),
+              );
+            } catch (e) {
+              assert(e instanceof Error);
+              this.logger.warning(
+                `Failed to scrape course details from '${course.url}': ${e.message}\n${e.stack}`,
+              );
               return;
             }
+            const urls = courseDetails.urls;
+            course.courseCode = courseDetails.courseCode;
+            course.name = courseDetails.courseName;
+            course.groups = urls.map((url) => {
+              return { url, groups: [] };
+            });
+          });
+        });
+      }),
+    );
 
-            const lecturers = details.lecturer
-              .trim()
-              .replace(/\s+/g, " ")
-              .slice(0, 255)
-              .split(", ");
+    task.update("Updating");
+    // set all courses to inactive
+    await Course.query().update({ isActive: false });
 
-            const lecturerIds = await Promise.all(
-              lecturers.map(async (lecturer) => {
-                const [name, ...surnameParts] = lecturer.split(" ");
-                const surname = surnameParts.join(" ");
+    // then push new active courses
+    const toInsert = this.departments.flatMap((department) => {
+      return department.registrations.flatMap((registration) =>
+        registration.courses.map((course) => {
+          return {
+            id:
+              course.courseCode +
+              (extractLastStringInBrackets(registration.name) ??
+                registration.name),
+            name: course.name,
+            registrationId:
+              extractLastStringInBrackets(registration.name) ??
+              registration.name,
+            isActive: true,
+          };
+        }),
+      );
+    });
+    await Promise.all(
+      chunkArray(toInsert, QUERY_CHUNK_SIZE).map((chunk) =>
+        this.dbSemaphore.runTask(() => Course.updateOrCreateMany("id", chunk)),
+      ),
+    );
+  }
 
-                const existingLecturer = await Lecturer.query()
-                  .where("name", name)
-                  .andWhere("surname", surname)
-                  .first();
+  async synchronizeArchivesTask(task: TaskHandle) {
+    task.update("Synchronizing archived groups");
+    const currentGroups = await Group.all();
 
-                if (existingLecturer !== null) {
-                  return existingLecturer.id;
-                } else {
-                  const dbLecturer = await Lecturer.create({ name, surname });
-                  return dbLecturer.id;
-                }
-              }),
-            );
+    const archivedGroups = await Promise.all(
+      chunkArray(currentGroups, QUERY_CHUNK_SIZE).map((chunk) =>
+        this.dbSemaphore.runTask(() =>
+          GroupArchive.updateOrCreateMany(
+            "id",
+            chunk.map((g) => g.$attributes),
+          ),
+        ),
+      ),
+    ).then((a) => a.flat());
 
-            for (const day of details.days) {
-              const group = await Group.updateOrCreate(
-                {
-                  name: details.name.slice(0, 255),
-                  startTime: details.startTimeEndTimes[
-                    details.days.indexOf(day)
-                  ].startTime.slice(0, 255),
-                  endTime: details.startTimeEndTimes[
-                    details.days.indexOf(day)
-                  ].endTime.slice(0, 255),
-                  group: details.group.slice(0, 255),
-                  week: details.week,
-                  day: day.slice(0, 255),
-                  type: details.type.slice(0, 255),
-                  courseId:
-                    course.courseCode.slice(0, 255) +
-                    (extractLastStringInBrackets(registration.name) ??
-                      registration.name),
-                },
-                {
-                  name: details.name.slice(0, 255),
-                  startTime: details.startTimeEndTimes[
-                    details.days.indexOf(day)
-                  ].startTime.slice(0, 255),
-                  endTime: details.startTimeEndTimes[
-                    details.days.indexOf(day)
-                  ].endTime.slice(0, 255),
-                  group: details.group.slice(0, 255),
-                  week: details.week,
-                  day: day.slice(0, 255),
-                  type: details.type.slice(0, 255),
-                  courseId:
-                    course.courseCode.slice(0, 255) +
-                    (extractLastStringInBrackets(registration.name) ??
-                      registration.name),
-                  spotsOccupied: details.spotsOccupied,
-                  spotsTotal: details.spotsTotal,
-                  url: url.slice(0, 255),
-                  isActive: true,
-                },
+    task.update("Synchronizing archived group lecturers");
+    await Promise.all(
+      zip(currentGroups, archivedGroups).map(([group, groupArchive]) =>
+        this.dbSemaphore.runTask(async () => {
+          const lecturers = await group.related("lecturers").query();
+
+          await groupArchive
+            .related("lecturers")
+            .sync(lecturers.map((lecturer) => lecturer.id));
+        }),
+      ),
+    );
+  }
+
+  async scrapeGroupsTask(task: TaskHandle) {
+    task.update("Fetching");
+
+    const fetchedDetails = await Promise.all(
+      this.departments.flatMap((department) =>
+        department.registrations.flatMap((registration) =>
+          registration.courses.flatMap((course) =>
+            course.groups.map(async (group) => {
+              let urls;
+              try {
+                urls = await this.scrapingSemaphore.runTask(() =>
+                  scrapGroupsUrls(group.url),
+                );
+              } catch (e) {
+                assert(e instanceof Error);
+                this.logger.warning(
+                  `Failed to fetch group detail URLs from '${group.url}': ${e.message}\n${e.stack}`,
+                );
+                return;
+              }
+
+              return await Promise.all(
+                urls.map(async (url) => {
+                  let details;
+                  try {
+                    details = await this.scrapingSemaphore.runTask(() =>
+                      scrapGroupDetails(url),
+                    );
+                  } catch (e) {
+                    assert(e instanceof Error);
+                    this.logger.warning(
+                      `Failed to fetch group details from '${url}': ${e.message}\n${e.stack}`,
+                    );
+                    return;
+                  }
+
+                  const lecturers = details.lecturer
+                    .trim()
+                    .replace(/\s+/g, " ")
+                    .slice(0, 255)
+                    .split(", ");
+
+                  return { url, registration, course, details, lecturers };
+                }),
               );
-              processedGroupIds.push(group.id);
+            }),
+          ),
+        ),
+      ),
+    ).then((r) => r.flat().filter((e) => e !== undefined));
 
-              await group.related("lecturers").sync(lecturerIds);
-            }
-          }),
-        );
-      }
-    }
-    await Group.query()
-      .whereNotIn("id", processedGroupIds)
-      .update({ isActive: false });
-    this.logger.log("Groups details scraped");
+    task.update("Updating lecturers");
+
+    // Create a deduplicated list of extracted lecturers
+    const lecturerSet = Array.from(
+      new Set(fetchedDetails.flatMap(({ lecturers }) => lecturers)),
+    );
+
+    // Then fetch/create their IDs from the DB
+    const lecturersToInsert = lecturerSet.map((lecturer) => {
+      const [name, ...surnameParts] = lecturer.split(" ");
+      const surname = surnameParts.join(" ");
+      return { name, surname };
+    });
+    const lecturersIds = await Promise.all(
+      chunkArray(lecturersToInsert, QUERY_CHUNK_SIZE).map((chunk) =>
+        this.dbSemaphore.runTask(() =>
+          Lecturer.fetchOrCreateMany(["name", "surname"], chunk),
+        ),
+      ),
+    ).then((a) => a.flat().map((l) => l.id));
+
+    // Finally, create a map of lecturer name to ID
+    const lecturerMap = new Map(zip(lecturerSet, lecturersIds));
+
+    task.update("Updating groups");
+    // set all groups to inactive, query below will activate scraped ones
+    await Group.query().update({ isActive: false });
+    const groupQueue = fetchedDetails.flatMap(
+      ({ url, registration, course, details }) =>
+        details.days.map((day) => {
+          return {
+            name: details.name.slice(0, 255),
+            startTime: details.startTimeEndTimes[
+              details.days.indexOf(day)
+            ].startTime.slice(0, 255),
+            endTime: details.startTimeEndTimes[
+              details.days.indexOf(day)
+            ].endTime.slice(0, 255),
+            group: details.group.slice(0, 255),
+            week: details.week as "-" | "TP" | "TN",
+            day: day.slice(0, 255),
+            type: details.type.slice(0, 255),
+            courseId:
+              course.courseCode.slice(0, 255) +
+              (extractLastStringInBrackets(registration.name) ??
+                registration.name),
+            spotsOccupied: details.spotsOccupied,
+            spotsTotal: details.spotsTotal,
+            url: url.slice(0, 255),
+            isActive: true,
+          };
+        }),
+    );
+    const groups = await Promise.all(
+      chunkArray(groupQueue, QUERY_CHUNK_SIZE).map((chunk) =>
+        this.dbSemaphore.runTask(() =>
+          Group.updateOrCreateMany(
+            [
+              "name",
+              "startTime",
+              "endTime",
+              "group",
+              "week",
+              "day",
+              "type",
+              "courseId",
+            ],
+            chunk,
+          ),
+        ),
+      ),
+    ).then((a) => a.flat());
+
+    task.update("Updating group lecturers");
+    const groupLecturers = zip(
+      fetchedDetails.flatMap(({ lecturers, details }) => {
+        const ids = lecturers.map((lecturer) => {
+          const id = lecturerMap.get(lecturer);
+          assert(id !== undefined);
+          return id;
+        });
+        return details.days.map(() => ids);
+      }),
+      groups,
+    );
+
+    await Promise.all(
+      groupLecturers.map(([lecturers, group]) =>
+        this.dbSemaphore.runTask(() =>
+          group.related("lecturers").sync(lecturers),
+        ),
+      ),
+    );
+  }
+
+  async run() {
+    this.scrapingSemaphore = new Semaphore(this.maxUsosRequests);
+    this.dbSemaphore = new Semaphore(this.maxDbRequests);
+
+    await this.ui
+      .tasks({ verbose: true })
+      .add("Scrape departments", async (task) => {
+        await this.departmentScrapeTask(task);
+        return "Done";
+      })
+      .add("Scrape registrations", async (task) => {
+        await this.registrationScrapeTask(task);
+        return "Done";
+      })
+      .add("Scrape course URLs", async () => {
+        await this.courseUrlScrapeTask();
+        return "Done";
+      })
+      .add("Scrape course details", async (task) => {
+        await this.courseDetailScrapeTask(task);
+        return "Done";
+      })
+      .add("Archive current groups", async (task) => {
+        await this.synchronizeArchivesTask(task);
+        return "Done";
+      })
+      .add("Scrape groups", async (task) => {
+        await this.scrapeGroupsTask(task);
+        return "Done";
+      })
+      .run();
   }
 }

--- a/backend/commands/scraper.ts
+++ b/backend/commands/scraper.ts
@@ -512,6 +512,24 @@ export default class Scraper extends BaseCommand {
     );
   }
 
+  async vacuumTablesTask(task: TaskHandle) {
+    const tables = [
+      "departments",
+      "registrations",
+      "courses",
+      "groups_archive",
+      "group_archive_lecturers",
+      "lecturers",
+      "groups",
+      "group_lecturers",
+    ];
+
+    for (const table of tables) {
+      task.update(`Vacuuming '${table}'`);
+      await db.rawQuery("VACUUM ANALYZE ??", [table]);
+    }
+  }
+
   async run() {
     this.scrapingSemaphore = new Semaphore(this.maxUsosRequests);
     this.dbSemaphore = new Semaphore(this.maxDbRequests);
@@ -540,6 +558,10 @@ export default class Scraper extends BaseCommand {
       })
       .add("Scrape groups", async (task) => {
         await this.scrapeGroupsTask(task);
+        return "Done";
+      })
+      .add("Vacuum & analyze tables", async (task) => {
+        await this.vacuumTablesTask(task);
         return "Done";
       })
       .run();

--- a/backend/database/migrations/1739621172974_groups_add_unique_index.ts
+++ b/backend/database/migrations/1739621172974_groups_add_unique_index.ts
@@ -7,7 +7,7 @@ export default class extends BaseSchema {
     await this.db.rawQuery(`
       BEGIN;
       WITH "duplicates" AS (
-        SELECT MAX("id") AS "id", "name", "start_time", "end_time", "group", "week", "day", "type", "course_id"
+        SELECT MIN("id") AS "id", "name", "start_time", "end_time", "group", "week", "day", "type", "course_id"
         FROM "groups"
         GROUP BY "name", "start_time", "end_time", "group", "week", "day", "type", "course_id"
         HAVING COUNT(*) > 1

--- a/backend/database/migrations/1739621172974_groups_add_unique_index.ts
+++ b/backend/database/migrations/1739621172974_groups_add_unique_index.ts
@@ -1,0 +1,39 @@
+import { BaseSchema } from "@adonisjs/lucid/schema";
+
+export default class extends BaseSchema {
+  protected tableName = "groups";
+
+  async up() {
+    await this.db.rawQuery(`
+      BEGIN;
+      WITH "duplicates" AS (
+        SELECT MAX("id") AS "id", "name", "start_time", "end_time", "group", "week", "day", "type", "course_id"
+        FROM "groups"
+        GROUP BY "name", "start_time", "end_time", "group", "week", "day", "type", "course_id"
+        HAVING COUNT(*) > 1
+      )
+      DELETE FROM "groups"
+      USING "duplicates"
+      WHERE "groups"."id" <> "duplicates"."id"
+        AND "groups"."name" = "duplicates"."name"
+        AND "groups"."start_time" = "duplicates"."start_time"
+        AND "groups"."end_time" = "duplicates"."end_time"
+        AND "groups"."group" = "duplicates"."group"
+        AND "groups"."week" = "duplicates"."week"
+        AND "groups"."day" = "duplicates"."day"
+        AND "groups"."type" = "duplicates"."type"
+        AND "groups"."course_id" = "duplicates"."course_id";
+      ALTER TABLE "groups"
+      ADD CONSTRAINT "groups_scraper_uindex"
+      UNIQUE ("name", "start_time", "end_time", "group", "week", "day", "type", "course_id");
+      COMMIT;
+    `);
+  }
+
+  async down() {
+    await this.db.rawQuery(`
+      ALTER TABLE "groups"
+      DROP CONSTRAINT "groups_scraper_uindex";
+    `);
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "#providers/*": "./providers/*.js",
     "#policies/*": "./app/policies/*.js",
     "#abilities/*": "./app/abilities/*.js",
+    "#utils/*": "./app/utils/*.js",
     "#database/*": "./database/*.js",
     "#start/*": "./start/*.js",
     "#tests/*": "./tests/*.js",

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -3,5 +3,8 @@
   "compilerOptions": {
     "rootDir": "./",
     "outDir": "./build"
+  },
+  "paths": {
+    "#utils": ["./app/utils/*.js"]
   }
 }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -6,7 +6,7 @@ import { auth } from "./lib/auth";
 export async function middleware(request: NextRequest) {
   const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
   const cspHeader = `
-    default-src 'self' 'nonce-${nonce}' https://fonts.googleapis.com https://fonts.gstatic.com https://analytics.solvro.pl;
+    default-src 'self' 'nonce-${nonce}' https://fonts.googleapis.com https://fonts.gstatic.com https://analytics.solvro.pl ${process.env.NODE_ENV === "development" ? "http://localhost:3333" : ""};
     script-src 'self' 'nonce-${nonce}' 'strict-dynamic' ${process.env.NODE_ENV === "development" ? "'unsafe-eval'" : ""} https://analytics.solvro.pl;
     style-src 'self' 'unsafe-inline';
     img-src 'self' blob: data: https://avatars.githubusercontent.com https://wit.pwr.edu.pl https://cms.solvro.pl https://apps.usos.pwr.edu.pl;


### PR DESCRIPTION
this pr does the following to the scraper command:
- split the main `run()` function into multiple task functions
- added fancy progress tracking logs with task timings
- task functions may share data between them using properties of the command object
- tasks should batch updates and run them all in a few queries by using the `*Many()` method variants of lucid models
- implemented simple async semaphores for ratelimiting
- the number of running parallel fetch and DB tasks is limited and can be adjusted using commandline flags
- it actually works now (on my machine) ~~(except it kinda doesnt)~~ (now it does)
- reimplemented the archive task in raw SQL

todo: (required before merge)
~~figure out why courses are always being duplicated on each scrape~~ done

further optimization possibilities:
~~the archive task could probably be rewritten in raw sql for better performance~~ done