### PR TITLE
fix(frontend): update occupied spots

### DIFF
--- a/frontend/src/lib/utils/update-spots-occupied.tsx
+++ b/frontend/src/lib/utils/update-spots-occupied.tsx
@@ -1,0 +1,102 @@
+import type { UseMutationResult } from "@tanstack/react-query";
+
+import type { ExtendedCourse, ExtendedGroup } from "@/atoms/plan-family";
+import type { LessonType } from "@/services/usos/types";
+import type { CourseType } from "@/types";
+
+import type { usePlanType } from "../use-plan";
+
+type UpdateSpotsOccupiedResult =
+  | {
+      status: "ERROR";
+      message: string;
+    }
+  | {
+      status: "SUCCESS";
+      updatedCourses: ExtendedCourse[];
+      isChanged: boolean;
+    };
+
+export const updateSpotsOccupied = async ({
+  plan,
+  coursesFunction,
+}: {
+  plan: usePlanType;
+  coursesFunction: UseMutationResult<CourseType, Error, string>;
+}): Promise<UpdateSpotsOccupiedResult> => {
+  let updatedCourses: ExtendedCourse[] = [];
+  let isChanged = false;
+
+  for (const registration of plan.registrations) {
+    try {
+      const courses = await coursesFunction.mutateAsync(registration.id);
+      const extendedCourses: ExtendedCourse[] = courses
+        .map((c) => {
+          const groups: ExtendedGroup[] = c.groups.map((g) => {
+            const currentGroup = plan.courses
+              .find((course) => course.id === c.id)
+              ?.groups.find(
+                (group) => group.groupId === g.group + c.id + g.type,
+              );
+            if (currentGroup === undefined) {
+              return {
+                groupId: g.group + c.id + g.type,
+                groupNumber: g.group.toString(),
+                groupOnlineId: g.id,
+                courseId: c.id,
+                courseName: c.name,
+                isChecked:
+                  plan.courses
+                    .find((oc) => oc.id === c.id)
+                    ?.groups.some(
+                      (og) => og.groupId === g.group + c.id + g.type,
+                    ) ?? false,
+                courseType: g.type,
+                day: g.day,
+                lecturer: g.lecturer,
+                registrationId: c.registrationId,
+                week: g.week.replace("-", "") as "" | "TN" | "TP",
+                endTime: g.endTime.split(":").slice(0, 2).join(":"),
+                startTime: g.startTime.split(":").slice(0, 2).join(":"),
+                spotsOccupied: g.spotsOccupied,
+                spotsTotal: g.spotsTotal,
+                opinionsCount: g.opinionsCount,
+                averageRating: g.averageRating,
+              };
+            } else if (currentGroup.spotsOccupied === g.spotsOccupied) {
+              return currentGroup;
+            }
+            isChanged = true;
+            return {
+              ...currentGroup,
+              spotsOccupied: g.spotsOccupied,
+              spotsTotal: g.spotsTotal,
+            };
+          });
+          return {
+            id: c.id,
+            name: c.name,
+            isChecked: plan.courses.some((oc) => oc.id === c.id),
+            registrationId: c.registrationId,
+            type: c.groups.at(0)?.type ?? ("" as LessonType),
+            groups,
+          };
+        })
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+      // Add unique courses to the updatedCourses array
+      updatedCourses = [...updatedCourses, ...extendedCourses].filter(
+        (course, index, array) =>
+          array.findIndex((t) => t.id === course.id) === index,
+      );
+    } catch {
+      return { status: "ERROR", message: "Nie udało się pobrać kursów" };
+    }
+  }
+
+  return {
+    status: "SUCCESS",
+    updatedCourses,
+    isChanged,
+  };
+};

--- a/frontend/src/lib/utils/update-spots-occupied.tsx
+++ b/frontend/src/lib/utils/update-spots-occupied.tsx
@@ -32,37 +32,14 @@ export const updateSpotsOccupied = async ({
       const courses = await coursesFunction.mutateAsync(registration.id);
       const extendedCourses: ExtendedCourse[] = courses
         .map((c) => {
-          const groups: ExtendedGroup[] = c.groups.map((g) => {
+          const groups: (ExtendedGroup | null)[] = c.groups.map((g) => {
             const currentGroup = plan.courses
               .find((course) => course.id === c.id)
               ?.groups.find(
                 (group) => group.groupId === g.group + c.id + g.type,
               );
             if (currentGroup === undefined) {
-              return {
-                groupId: g.group + c.id + g.type,
-                groupNumber: g.group.toString(),
-                groupOnlineId: g.id,
-                courseId: c.id,
-                courseName: c.name,
-                isChecked:
-                  plan.courses
-                    .find((oc) => oc.id === c.id)
-                    ?.groups.some(
-                      (og) => og.groupId === g.group + c.id + g.type,
-                    ) ?? false,
-                courseType: g.type,
-                day: g.day,
-                lecturer: g.lecturer,
-                registrationId: c.registrationId,
-                week: g.week.replace("-", "") as "" | "TN" | "TP",
-                endTime: g.endTime.split(":").slice(0, 2).join(":"),
-                startTime: g.startTime.split(":").slice(0, 2).join(":"),
-                spotsOccupied: g.spotsOccupied,
-                spotsTotal: g.spotsTotal,
-                opinionsCount: g.opinionsCount,
-                averageRating: g.averageRating,
-              };
+              return null;
             } else if (currentGroup.spotsOccupied === g.spotsOccupied) {
               return currentGroup;
             }
@@ -79,7 +56,7 @@ export const updateSpotsOccupied = async ({
             isChecked: plan.courses.some((oc) => oc.id === c.id),
             registrationId: c.registrationId,
             type: c.groups.at(0)?.type ?? ("" as LessonType),
-            groups,
+            groups: groups.filter((g): g is ExtendedGroup => g !== null),
           };
         })
         .sort((a, b) => a.name.localeCompare(b.name));


### PR DESCRIPTION
This pull request introduces a new feature to update the spots occupied in courses within the `CreateNewPlanPage` component. It includes several changes to both the component and a new utility function. The most important changes are detailed below:

### Changes to `CreateNewPlanPage` component:

* Added `updateSpotsOccupied` import to `frontend/src/app/plans/edit/[id]/page.client.tsx` ([frontend/src/app/plans/edit/[id]/page.client.tsxR28](diffhunk://#diff-14dcdc3ba4c06f83798f84fc7b67821bf00cca4f895ae80904dc4adc2ad65909R28)).
* Introduced a new `spotsSynced` ref to track whether spots have been synced ([frontend/src/app/plans/edit/[id]/page.client.tsxR52](diffhunk://#diff-14dcdc3ba4c06f83798f84fc7b67821bf00cca4f895ae80904dc4adc2ad65909R52)).
* Added `handleUpdateSpotsOccupied` function to update the spots occupied in courses ([frontend/src/app/plans/edit/[id]/page.client.tsxR184-R200](diffhunk://#diff-14dcdc3ba4c06f83798f84fc7b67821bf00cca4f895ae80904dc4adc2ad65909R184-R200)).
* Implemented a `useEffect` hook to call `handleUpdateSpotsOccupied` on component mount ([frontend/src/app/plans/edit/[id]/page.client.tsxR230-R236](diffhunk://#diff-14dcdc3ba4c06f83798f84fc7b67821bf00cca4f895ae80904dc4adc2ad65909R230-R236)).

### New utility function:

* Created `updateSpotsOccupied` function in `frontend/src/lib/utils/update-spots-occupied.tsx` to handle the update logic for spots occupied in courses.