### PR TITLE
Fix schedule download on mobile

### DIFF
--- a/frontend/src/app/plans/_components/download-button.tsx
+++ b/frontend/src/app/plans/_components/download-button.tsx
@@ -25,7 +25,11 @@ export function DownloadPlanButton({
     setLoading(true);
     const element = captureRef.current;
     try {
-      const dataUrl = await toPng(element, { cacheBust: true });
+      const dataUrl = await toPng(element, {
+        cacheBust: true,
+        width: element.scrollWidth,
+        height: element.scrollHeight,
+      });
       const link = document.createElement("a");
       link.download = `${plan.name}.png`;
       link.href = dataUrl;


### PR DESCRIPTION
This very small pull request includes a modification to the `DownloadPlanButton` component in the `frontend/src/app/plans/_components/download-button.tsx` file to fix plan being cut off when downloading on mobile (or any device with smaller screen than the schedule).
