### PR TITLE
feat: better query cache

### DIFF
--- a/frontend/src/app/plans/edit/[id]/page.client.tsx
+++ b/frontend/src/app/plans/edit/[id]/page.client.tsx
@@ -5,7 +5,6 @@ import { AnimatePresence, motion } from "motion/react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { useLocalStorage } from "react-use";
 import { toast } from "sonner";
 
 import { getPlan } from "@/actions/plans";
@@ -26,7 +25,7 @@ import { fetchClient } from "@/lib/fetch";
 import { usePlan } from "@/lib/use-plan";
 import { updateSpotsOccupied } from "@/lib/utils/update-spots-occupied";
 import { Day } from "@/types";
-import type { CourseType, PlanResponseType } from "@/types";
+import type { CourseType } from "@/types";
 
 import { DownloadPlanButton } from "../../_components/download-button";
 import { SharePlanButton } from "../../_components/share-plan-button";
@@ -50,11 +49,6 @@ export function CreateNewPlanPage({ planId }: { planId: string }) {
   const router = useRouter();
   const plan = usePlan({ planId });
 
-  const [value] = useLocalStorage<{
-    cached: Date | null;
-    onlinePlan: PlanResponseType | null;
-  }>(`locale-cache-${plan.id}`);
-
   const {
     data: onlinePlan,
     refetch: refetchOnlinePlan,
@@ -62,7 +56,6 @@ export function CreateNewPlanPage({ planId }: { planId: string }) {
   } = useQuery({
     enabled: plan.onlineId !== null && plan.onlineId !== "",
     queryKey: ["onlinePlan", plan.onlineId],
-    initialData: value?.onlinePlan,
     queryFn: async () => {
       const response = await getPlan({ id: Number(plan.onlineId) });
       if (


### PR DESCRIPTION
This pull request removes the use of `useLocalStorage` for caching online plans and replaces it with `react-query` for improved state management and caching. It also includes minor cleanup of unused imports.

### Removal of `useLocalStorage` for caching:

* `frontend/src/app/plans/edit/[id]/page.client.tsx`: Removed the `useLocalStorage` hook and its associated logic for caching online plans. The `initialData` for the `useQuery` hook is no longer set from local storage. ([frontend/src/app/plans/edit/[id]/page.client.tsxL8](diffhunk://#diff-14dcdc3ba4c06f83798f84fc7b67821bf00cca4f895ae80904dc4adc2ad65909L8), [frontend/src/app/plans/edit/[id]/page.client.tsxL53-L65](diffhunk://#diff-14dcdc3ba4c06f83798f84fc7b67821bf00cca4f895ae80904dc4adc2ad65909L53-L65))
* [`frontend/src/components/plan-item.tsx`](diffhunk://#diff-e09735cba58e940bef3d1e1d1576215f076bfbeb9f0748ccc817dd13d8f8b2c3R3-R9): Removed the `useLocalStorage` hook and replaced the caching logic in `handleCacheOnlinePlan` with `react-query`'s `prefetchQuery` method. This change simplifies the caching mechanism and leverages `react-query` for better consistency. [[1]](diffhunk://#diff-e09735cba58e940bef3d1e1d1576215f076bfbeb9f0748ccc817dd13d8f8b2c3R3-R9) [[2]](diffhunk://#diff-e09735cba58e940bef3d1e1d1576215f076bfbeb9f0748ccc817dd13d8f8b2c3L76-L79) [[3]](diffhunk://#diff-e09735cba58e940bef3d1e1d1576215f076bfbeb9f0748ccc817dd13d8f8b2c3R135-R148)

### Cleanup of unused imports:

* `frontend/src/app/plans/edit/[id]/page.client.tsx`: Removed unused imports, including `useLocalStorage` and `PlanResponseType`. ([frontend/src/app/plans/edit/[id]/page.client.tsxL8](diffhunk://#diff-14dcdc3ba4c06f83798f84fc7b67821bf00cca4f895ae80904dc4adc2ad65909L8), [frontend/src/app/plans/edit/[id]/page.client.tsxL29-R28](diffhunk://#diff-14dcdc3ba4c06f83798f84fc7b67821bf00cca4f895ae80904dc4adc2ad65909L29-R28))
* [`frontend/src/components/plan-item.tsx`](diffhunk://#diff-e09735cba58e940bef3d1e1d1576215f076bfbeb9f0748ccc817dd13d8f8b2c3R3-R9): Removed unused imports, including `useLocalStorage` and `PlanResponseType`. [[1]](diffhunk://#diff-e09735cba58e940bef3d1e1d1576215f076bfbeb9f0748ccc817dd13d8f8b2c3R3-R9) [[2]](diffhunk://#diff-e09735cba58e940bef3d1e1d1576215f076bfbeb9f0748ccc817dd13d8f8b2c3L32)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaced `useLocalStorage` with `react-query` for caching in `page.client.tsx` and `plan-item.tsx`, and cleaned up unused imports.
> 
>   - **Caching**:
>     - Replaced `useLocalStorage` with `react-query` in `page.client.tsx` and `plan-item.tsx` for caching online plans.
>     - Removed `useLocalStorage` logic and replaced with `react-query`'s `prefetchQuery` in `handleCacheOnlinePlan()` in `plan-item.tsx`.
>   - **Imports Cleanup**:
>     - Removed unused imports, including `useLocalStorage` and `PlanResponseType`, in `page.client.tsx` and `plan-item.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fweb-planer&utm_source=github&utm_medium=referral)<sup> for 695754933aeb39aea88351fe3a40667fb5dce80b. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->