### PR TITLE
refactor: move server to local plan logic to one file

### DIFF
--- a/frontend/src/app/plans/edit/[id]/_components/app-sidebar.tsx
+++ b/frontend/src/app/plans/edit/[id]/_components/app-sidebar.tsx
@@ -8,7 +8,6 @@ import Link from "next/link";
 import React from "react";
 
 import { getFaculties } from "@/actions/get-faculties";
-import type { ExtendedCourse, ExtendedGroup } from "@/atoms/plan-family";
 import { GroupsAccordionItem } from "@/components/groups-accordion";
 import { Icons } from "@/components/icons";
 import { PlanDisplayLink } from "@/components/plan-display-link";
@@ -33,12 +32,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { fetchClient } from "@/lib/fetch";
 import type { usePlanType } from "@/lib/use-plan";
 import { registrationReplacer } from "@/lib/utils";
-import type {
-  CourseType,
-  FacultyType,
-  LessonType,
-  PlanResponseType,
-} from "@/types";
+import { serverToLocalPlan } from "@/lib/utils/server-to-local-plan";
+import type { CourseType, FacultyType, PlanResponseType } from "@/types";
 
 import { OfflineAlert } from "./offline-alert";
 import { SyncErrorAlert } from "./sync-error-alert";
@@ -240,48 +235,11 @@ export function AppSidebar({
                   } else {
                     coursesFunction.mutate(selectedRegistration.id, {
                       onSuccess: (data) => {
-                        const extendedCourses: ExtendedCourse[] = data
-                          .map((c) => ({
-                            id: c.id,
-                            name: c.name,
-                            isChecked: true,
-                            registrationId: c.registrationId,
-                            type: c.groups.at(0)?.type ?? ("" as LessonType),
-                            groups: c.groups.map(
-                              (g) =>
-                                ({
-                                  groupId: g.group + c.id + g.type,
-                                  groupNumber: g.group.toString(),
-                                  groupOnlineId: g.id,
-                                  courseId: c.id,
-                                  courseName: c.name,
-                                  isChecked: false,
-                                  courseType: g.type,
-                                  day: g.day,
-                                  lecturer: g.lecturer,
-                                  registrationId: c.registrationId,
-                                  week: g.week.replace("-", "") as
-                                    | ""
-                                    | "TN"
-                                    | "TP",
-                                  endTime: g.endTime
-                                    .split(":")
-                                    .slice(0, 2)
-                                    .join(":"),
-                                  startTime: g.startTime
-                                    .split(":")
-                                    .slice(0, 2)
-                                    .join(":"),
-                                  spotsOccupied: g.spotsOccupied,
-                                  spotsTotal: g.spotsTotal,
-                                  averageRating: g.averageRating,
-                                  opinionsCount: g.opinionsCount,
-                                }) satisfies ExtendedGroup,
-                            ),
-                          }))
-                          .sort((a, b) => {
-                            return a.name.localeCompare(b.name);
-                          });
+                        const extendedCourses = serverToLocalPlan(
+                          data,
+                          true,
+                          false,
+                        );
                         plan.addRegistration(
                           selectedRegistration,
                           extendedCourses,

--- a/frontend/src/lib/utils/server-to-local-plan.ts
+++ b/frontend/src/lib/utils/server-to-local-plan.ts
@@ -1,0 +1,56 @@
+import type { ExtendedCourse, ExtendedGroup } from "@/atoms/plan-family";
+import type {
+  CourseType,
+  LessonType,
+  SingleCourse,
+  SingleGroup,
+} from "@/types";
+
+export const serverToLocalPlan = (
+  courses: CourseType,
+  shouldCourseBeChecked: ((course: SingleCourse) => boolean) | boolean,
+  shouldGroupBeChecked:
+    | ((course: SingleCourse, group: SingleGroup) => boolean)
+    | boolean,
+) => {
+  const extendedCourses: ExtendedCourse[] = courses
+    .map((c) => ({
+      id: c.id,
+      name: c.name,
+      isChecked:
+        typeof shouldCourseBeChecked === "boolean"
+          ? shouldCourseBeChecked
+          : shouldCourseBeChecked(c),
+      registrationId: c.registrationId,
+      type: c.groups.at(0)?.type ?? ("" as LessonType),
+      groups: c.groups.map(
+        (g) =>
+          ({
+            groupId: g.group + c.id + g.type,
+            groupNumber: g.group.toString(),
+            groupOnlineId: g.id,
+            courseId: c.id,
+            courseName: c.name,
+            isChecked:
+              typeof shouldGroupBeChecked === "boolean"
+                ? shouldGroupBeChecked
+                : shouldGroupBeChecked(c, g),
+            courseType: g.type,
+            day: g.day,
+            lecturer: g.lecturer,
+            registrationId: c.registrationId,
+            week: g.week.replace("-", "") as "" | "TN" | "TP",
+            endTime: g.endTime.split(":").slice(0, 2).join(":"),
+            startTime: g.startTime.split(":").slice(0, 2).join(":"),
+            spotsOccupied: g.spotsOccupied,
+            spotsTotal: g.spotsTotal,
+            averageRating: g.averageRating,
+            opinionsCount: g.opinionsCount,
+          }) satisfies ExtendedGroup,
+      ),
+    }))
+    .sort((a, b) => {
+      return a.name.localeCompare(b.name);
+    });
+  return extendedCourses;
+};

--- a/frontend/src/lib/utils/update-local-plan.ts
+++ b/frontend/src/lib/utils/update-local-plan.ts
@@ -49,11 +49,11 @@ export const updateLocalPlan = async (
         (course: SingleCourse) => {
           return onlinePlan.courses.some((oc) => oc.id === course.id);
         },
-        (courseId: SingleCourse, groupId: SingleGroup) => {
+        (course: SingleCourse, group: SingleGroup) => {
           return (
             onlinePlan.courses
-              .find((oc) => oc.id === courseId.id)
-              ?.groups.some((og) => og.id === groupId.id) ?? false
+              .find((oc) => oc.id === course.id)
+              ?.groups.some((og) => og.id === group.id) ?? false
           );
         },
       );

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -124,30 +124,34 @@ export interface DeletePlanResponseType {
   message: string;
 }
 
-export type CourseType = {
+export interface SingleGroup {
+  id: number;
+  name: string;
+  startTime: string;
+  endTime: string;
+  group: string;
+  lecturer: string;
+  week: "-" | "TN" | "TP";
+  day: Day;
+  type: "C" | "L" | "P" | "S" | "W";
+  url: string;
+  courseId: string;
+  spotsOccupied: number;
+  spotsTotal: number;
+  averageRating: number;
+  createdAt: string;
+  updatedAt: string;
+  opinionsCount: number;
+}
+
+export interface SingleCourse {
   id: string;
   name: string;
   registrationId: string;
-  groups: {
-    id: number;
-    name: string;
-    startTime: string;
-    endTime: string;
-    group: string;
-    lecturer: string;
-    week: "-" | "TN" | "TP";
-    day: Day;
-    type: "C" | "L" | "P" | "S" | "W";
-    url: string;
-    courseId: string;
-    spotsOccupied: number;
-    spotsTotal: number;
-    averageRating: number;
-    createdAt: string;
-    updatedAt: string;
-    opinionsCount: number;
-  }[];
-}[];
+  groups: SingleGroup[];
+}
+
+export type CourseType = SingleCourse[];
 
 export type FacultyType = {
   id: string;


### PR DESCRIPTION
Moved logic for changing server plans to local ones to one file, extracted types for single group and course in types file
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor server-to-local plan logic into a dedicated file and extract types for better code organization.
> 
>   - **Refactor**:
>     - Move logic for converting server plans to local plans to `server-to-local-plan.ts`.
>     - Use `serverToLocalPlan` in `app-sidebar.tsx` and `update-local-plan.ts` to replace inline logic.
>   - **Types**:
>     - Extract `SingleCourse` and `SingleGroup` types in `types/index.ts` for better type management.
>   - **Misc**:
>     - Remove unused imports in `app-sidebar.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fweb-planer&utm_source=github&utm_medium=referral)<sup> for 35e247fc058a8f72b0ceb1da0acac68319d6ccb8. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->