### PR TITLE
feat: add error toasts

### DIFF
--- a/frontend/src/actions/plans.ts
+++ b/frontend/src/actions/plans.ts
@@ -75,12 +75,18 @@ export const deletePlan = async ({ id }: { id: number }) => {
       method: "DELETE",
     });
     if (data === null) {
-      throw new Error("Failed to delete plan");
+      return {
+        success: false,
+        message: "Nie udało się usunąć planu",
+      };
     }
     revalidatePath("/plans");
     return data;
   } catch {
-    throw new Error("Not logged in");
+    return {
+      success: false,
+      message: "Nie udało się usunąć planu, użytkownik niezalogowany",
+    };
   }
 };
 

--- a/frontend/src/app/plans/edit/[id]/page.client.tsx
+++ b/frontend/src/app/plans/edit/[id]/page.client.tsx
@@ -80,13 +80,15 @@ export function CreateNewPlanPage({ planId }: { planId: string }) {
       });
 
       if (!response.ok) {
+        toast.error(
+          "Coś poszło nie tak podczas pobierania kursów, spróbuj ponownie",
+        );
         throw new Error("Network response was not ok");
       }
 
       return response.json() as Promise<CourseType>;
     },
   });
-
   const {
     syncing,
     handleSyncPlan,
@@ -132,7 +134,6 @@ export function CreateNewPlanPage({ planId }: { planId: string }) {
       </div>
     );
   }
-
   return (
     <>
       <AppSidebar

--- a/frontend/src/components/plan-item.tsx
+++ b/frontend/src/components/plan-item.tsx
@@ -117,12 +117,17 @@ export function PlanItem({
 
   const handleDeletePlan = async () => {
     setLoading(true);
+    if (onlineId !== null) {
+      const response = await deletePlan({ id: Number(onlineId) });
+      if (!response.success) {
+        toast.error(response.message);
+        setLoading(false);
+        return;
+      }
+    }
     plan.remove();
     if (!onlineOnly) {
       setPlans(plans.filter((p) => p.id !== id));
-    }
-    if (onlineId !== null) {
-      await deletePlan({ id: Number(onlineId) });
     }
     toast.success("Plan został usunięty.");
   };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds error toasts for failed plan deletions and course fetches, modifying `deletePlan` to return error messages.
> 
>   - **Behavior**:
>     - Adds error toasts in `CreateNewPlanPage` and `PlanItem` components for failed operations.
>     - Modifies `deletePlan` in `plans.ts` to return error messages instead of throwing exceptions.
>   - **Error Handling**:
>     - Displays toast error when `deletePlan` fails due to network issues or user not logged in.
>     - Displays toast error in `CreateNewPlanPage` when fetching courses fails.
>   - **Misc**:
>     - Adjusts `handleDeletePlan` in `PlanItem` to handle new `deletePlan` return structure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fweb-planer&utm_source=github&utm_medium=referral)<sup> for 630cb1af2b256b8d3407a965acdba7f4bb889c6b. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->