### PR TITLE
feat: add react email for email templates

### DIFF
--- a/.github/workflows/emails_ci.yaml
+++ b/.github/workflows/emails_ci.yaml
@@ -1,0 +1,25 @@
+name: Emails CI
+
+on:
+  push:
+    branches: ["main", "beta"]
+    paths:
+      - "emails/**"
+  pull_request:
+    branches: ["main", "beta"]
+    paths:
+      - "emails/**"
+
+jobs:
+  export:
+    name: Export emails
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: ./.github/composite-actions/install
+
+      - name: Export emails
+        run: pnpm email:export

--- a/emails/otp-email.tsx
+++ b/emails/otp-email.tsx
@@ -1,0 +1,126 @@
+import {
+  Body,
+  Column,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Img,
+  Link,
+  Preview,
+  Row,
+  Section,
+  Tailwind,
+  Text,
+} from "react-email";
+
+interface OtpEmailProps {
+  otp: string;
+}
+
+export function OtpEmail({ otp }: OtpEmailProps) {
+  return (
+    <Html lang="pl">
+      <Head />
+      <Preview>Twój kod logowania do Planera Solvro: {otp}</Preview>
+      <Tailwind>
+        <Body className="m-auto bg-zinc-100 font-sans">
+          <Container className="mx-auto my-10 max-w-[480px] rounded-lg bg-white p-10">
+            <Img
+              src={`https://planer.solvro.pl/assets/logo/solvro_black.png`}
+              width="auto"
+              height="40"
+              alt="Plaid"
+              className="mb-8 block"
+            />
+            <Heading className="mb-4 mt-0 p-0 text-2xl font-bold text-zinc-900">
+              Twój kod logowania
+            </Heading>
+            <Text className="mb-6 mt-0 text-sm text-zinc-500">
+              Użyj poniższego kodu, aby zalogować się do Planera Solvro:
+            </Text>
+            <Section className="mb-6 rounded-lg bg-zinc-100 py-6 text-center">
+              <Text className="m-0 text-4xl font-bold tracking-[8px] text-zinc-900">
+                {otp}
+              </Text>
+            </Section>
+            <Hr className="mb-6 border-zinc-200" />
+            <Text className="m-0 text-xs text-zinc-400">
+              Kod jest ważny przez 5 minut. <br />
+              Jeśli nie próbowałeś się zalogować, zignoruj tę wiadomość.
+            </Text>
+          </Container>
+
+          <Section className="text-center">
+            <table className="w-full">
+              <tr className="w-full">
+                <td align="center">
+                  <Img
+                    alt="React Email logo"
+                    height="auto"
+                    src="https://planer.solvro.pl/assets/logo/logo_solvro_color.png"
+                    width="42"
+                  />
+                </td>
+              </tr>
+              <tr className="w-full">
+                <td align="center">
+                  <Text className="my-[8px] text-[16px] font-semibold leading-[24px] text-gray-900">
+                    Koło Naukowe Solvro
+                  </Text>
+                  <Text className="mb-0 mt-[4px] text-[16px] leading-[24px] text-gray-500">
+                    Otwieramy drzwi do świata IT.
+                  </Text>
+                </td>
+              </tr>
+              <tr>
+                <td align="center">
+                  <Row className="table-cell h-[44px] w-[56px] align-bottom">
+                    <Column className="pr-[8px]">
+                      <Link href="https://www.facebook.com/knsolvro">
+                        <Img
+                          alt="Facebook"
+                          height="36"
+                          src="https://react.email/static/facebook-logo.png"
+                          width="36"
+                        />
+                      </Link>
+                    </Column>
+                    <Column>
+                      <Link href="https://www.instagram.com/knsolvro/">
+                        <Img
+                          alt="Instagram"
+                          height="36"
+                          src="https://react.email/static/instagram-logo.png"
+                          width="36"
+                        />
+                      </Link>
+                    </Column>
+                  </Row>
+                </td>
+              </tr>
+              <tr>
+                <td align="center">
+                  <Text className="my-[8px] text-[12px] font-medium leading-[14px] text-gray-500">
+                    Zygmunta Wróblewskiego 27 | Pokój nr 4, 51-627 Wrocław
+                  </Text>
+                  <Text className="mb-0 mt-[4px] text-[10px] leading-[12px] text-gray-500">
+                    kn.solvro@pwr.edu.pl
+                  </Text>
+                </td>
+              </tr>
+            </table>
+          </Section>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+}
+
+OtpEmail.PreviewProps = {
+  otp: "000000",
+} as OtpEmailProps;
+
+// eslint-disable-next-line import/no-default-export
+export default OtpEmail;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint:fix": "eslint . --fix",
     "lint:style": "next typegen & eslint . --max-warnings=0",
     "lint:typecheck": "next typegen & tsc --noEmit",
-    "start": "next start"
+    "start": "next start",
+    "email-dev": "email dev"
   },
   "lint-staged": {
     "*": "prettier -w --ignore-unknown"
@@ -37,6 +38,8 @@
     "@radix-ui/react-slot": "^1.1.1",
     "@radix-ui/react-switch": "^1.1.2",
     "@radix-ui/react-tooltip": "^1.1.4",
+    "@react-email/components": "^1.0.12",
+    "@react-email/render": "^2.0.8",
     "@t3-oss/env-nextjs": "^0.11.0",
     "@tanstack/react-query": "^5.54.1",
     "@types/canvas-confetti": "^1.9.0",
@@ -66,6 +69,7 @@
     "pg": "^8.20.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-email": "^6.0.8",
     "react-hook-form": "^7.54.2",
     "react-icons": "^5.3.0",
     "react-use": "^17.6.0",
@@ -78,6 +82,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@react-email/ui": "6.0.8",
     "@solvro/config": "^2.3.0",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@types/crypto-js": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "lint:style": "next typegen & eslint . --max-warnings=0",
     "lint:typecheck": "next typegen & tsc --noEmit",
     "start": "next start",
-    "email-dev": "email dev"
+    "email:dev": "email dev",
+    "email:export": "email export"
   },
   "lint-staged": {
     "*": "prettier -w --ignore-unknown"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "db:migrate": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",
     "dev": "next dev",
+    "email:dev": "email dev",
+    "email:export": "email export",
     "format:check": "prettier --check .",
     "format:fix": "prettier --write .",
     "knip": "knip",
@@ -16,9 +18,7 @@
     "lint:fix": "eslint . --fix",
     "lint:style": "next typegen & eslint . --max-warnings=0",
     "lint:typecheck": "next typegen & tsc --noEmit",
-    "start": "next start",
-    "email:dev": "email dev",
-    "email:export": "email export"
+    "start": "next start"
   },
   "lint-staged": {
     "*": "prettier -w --ignore-unknown"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,12 @@ importers:
       "@radix-ui/react-tooltip":
         specifier: ^1.1.4
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      "@react-email/components":
+        specifier: ^1.0.12
+        version: 1.0.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      "@react-email/render":
+        specifier: ^2.0.8
+        version: 2.0.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       "@t3-oss/env-nextjs":
         specifier: ^0.11.0
         version: 0.11.1(typescript@5.9.3)(zod@4.3.6)
@@ -140,6 +146,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      react-email:
+        specifier: ^6.0.8
+        version: 6.0.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-hook-form:
         specifier: ^7.54.2
         version: 7.71.2(react@19.2.4)
@@ -171,6 +180,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      "@react-email/ui":
+        specifier: 6.0.8
+        version: 6.0.8(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       "@solvro/config":
         specifier: ^2.3.0
         version: 2.3.0(@next/eslint-plugin-next@16.2.1)(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(class-validator@0.15.1)(eslint@9.39.4(jiti@1.21.7))(prettier@3.8.1)(typescript@5.9.3)
@@ -344,6 +356,14 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@babel/parser@7.27.0":
+    resolution:
+      {
+        integrity: sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==,
+      }
+    engines: { node: ">=6.0.0" }
+    hasBin: true
+
   "@babel/parser@7.29.0":
     resolution:
       {
@@ -363,6 +383,13 @@ packages:
     resolution:
       {
         integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/traverse@7.27.0":
+    resolution:
+      {
+        integrity: sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -621,6 +648,15 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  "@esbuild/aix-ppc64@0.28.0":
+    resolution:
+      {
+        integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ppc64]
+    os: [aix]
+
   "@esbuild/android-arm64@0.18.20":
     resolution:
       {
@@ -643,6 +679,15 @@ packages:
     resolution:
       {
         integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [android]
+
+  "@esbuild/android-arm64@0.28.0":
+    resolution:
+      {
+        integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -675,6 +720,15 @@ packages:
     cpu: [arm]
     os: [android]
 
+  "@esbuild/android-arm@0.28.0":
+    resolution:
+      {
+        integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm]
+    os: [android]
+
   "@esbuild/android-x64@0.18.20":
     resolution:
       {
@@ -697,6 +751,15 @@ packages:
     resolution:
       {
         integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [android]
+
+  "@esbuild/android-x64@0.28.0":
+    resolution:
+      {
+        integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -729,6 +792,15 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  "@esbuild/darwin-arm64@0.28.0":
+    resolution:
+      {
+        integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [darwin]
+
   "@esbuild/darwin-x64@0.18.20":
     resolution:
       {
@@ -751,6 +823,15 @@ packages:
     resolution:
       {
         integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [darwin]
+
+  "@esbuild/darwin-x64@0.28.0":
+    resolution:
+      {
+        integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -783,6 +864,15 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  "@esbuild/freebsd-arm64@0.28.0":
+    resolution:
+      {
+        integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [freebsd]
+
   "@esbuild/freebsd-x64@0.18.20":
     resolution:
       {
@@ -805,6 +895,15 @@ packages:
     resolution:
       {
         integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@esbuild/freebsd-x64@0.28.0":
+    resolution:
+      {
+        integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -837,6 +936,15 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  "@esbuild/linux-arm64@0.28.0":
+    resolution:
+      {
+        integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [linux]
+
   "@esbuild/linux-arm@0.18.20":
     resolution:
       {
@@ -859,6 +967,15 @@ packages:
     resolution:
       {
         integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm]
+    os: [linux]
+
+  "@esbuild/linux-arm@0.28.0":
+    resolution:
+      {
+        integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==,
       }
     engines: { node: ">=18" }
     cpu: [arm]
@@ -891,6 +1008,15 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  "@esbuild/linux-ia32@0.28.0":
+    resolution:
+      {
+        integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ia32]
+    os: [linux]
+
   "@esbuild/linux-loong64@0.18.20":
     resolution:
       {
@@ -913,6 +1039,15 @@ packages:
     resolution:
       {
         integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [loong64]
+    os: [linux]
+
+  "@esbuild/linux-loong64@0.28.0":
+    resolution:
+      {
+        integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==,
       }
     engines: { node: ">=18" }
     cpu: [loong64]
@@ -945,6 +1080,15 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  "@esbuild/linux-mips64el@0.28.0":
+    resolution:
+      {
+        integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==,
+      }
+    engines: { node: ">=18" }
+    cpu: [mips64el]
+    os: [linux]
+
   "@esbuild/linux-ppc64@0.18.20":
     resolution:
       {
@@ -967,6 +1111,15 @@ packages:
     resolution:
       {
         integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ppc64]
+    os: [linux]
+
+  "@esbuild/linux-ppc64@0.28.0":
+    resolution:
+      {
+        integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==,
       }
     engines: { node: ">=18" }
     cpu: [ppc64]
@@ -999,6 +1152,15 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  "@esbuild/linux-riscv64@0.28.0":
+    resolution:
+      {
+        integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [riscv64]
+    os: [linux]
+
   "@esbuild/linux-s390x@0.18.20":
     resolution:
       {
@@ -1021,6 +1183,15 @@ packages:
     resolution:
       {
         integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [s390x]
+    os: [linux]
+
+  "@esbuild/linux-s390x@0.28.0":
+    resolution:
+      {
+        integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==,
       }
     engines: { node: ">=18" }
     cpu: [s390x]
@@ -1053,6 +1224,15 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  "@esbuild/linux-x64@0.28.0":
+    resolution:
+      {
+        integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [linux]
+
   "@esbuild/netbsd-arm64@0.25.12":
     resolution:
       {
@@ -1066,6 +1246,15 @@ packages:
     resolution:
       {
         integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [netbsd]
+
+  "@esbuild/netbsd-arm64@0.28.0":
+    resolution:
+      {
+        integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -1098,6 +1287,15 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  "@esbuild/netbsd-x64@0.28.0":
+    resolution:
+      {
+        integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [netbsd]
+
   "@esbuild/openbsd-arm64@0.25.12":
     resolution:
       {
@@ -1111,6 +1309,15 @@ packages:
     resolution:
       {
         integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [openbsd]
+
+  "@esbuild/openbsd-arm64@0.28.0":
+    resolution:
+      {
+        integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -1143,6 +1350,15 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  "@esbuild/openbsd-x64@0.28.0":
+    resolution:
+      {
+        integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [openbsd]
+
   "@esbuild/openharmony-arm64@0.25.12":
     resolution:
       {
@@ -1156,6 +1372,15 @@ packages:
     resolution:
       {
         integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [openharmony]
+
+  "@esbuild/openharmony-arm64@0.28.0":
+    resolution:
+      {
+        integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -1188,6 +1413,15 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  "@esbuild/sunos-x64@0.28.0":
+    resolution:
+      {
+        integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [sunos]
+
   "@esbuild/win32-arm64@0.18.20":
     resolution:
       {
@@ -1210,6 +1444,15 @@ packages:
     resolution:
       {
         integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [win32]
+
+  "@esbuild/win32-arm64@0.28.0":
+    resolution:
+      {
+        integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
@@ -1242,6 +1485,15 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  "@esbuild/win32-ia32@0.28.0":
+    resolution:
+      {
+        integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ia32]
+    os: [win32]
+
   "@esbuild/win32-x64@0.18.20":
     resolution:
       {
@@ -1264,6 +1516,15 @@ packages:
     resolution:
       {
         integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [win32]
+
+  "@esbuild/win32-x64@0.28.0":
+    resolution:
+      {
+        integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -1870,6 +2131,12 @@ packages:
         integrity: sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==,
       }
 
+  "@next/env@16.2.3":
+    resolution:
+      {
+        integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==,
+      }
+
   "@next/eslint-plugin-next@16.2.1":
     resolution:
       {
@@ -1885,10 +2152,28 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  "@next/swc-darwin-arm64@16.2.3":
+    resolution:
+      {
+        integrity: sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==,
+      }
+    engines: { node: ">= 10" }
+    cpu: [arm64]
+    os: [darwin]
+
   "@next/swc-darwin-x64@16.1.6":
     resolution:
       {
         integrity: sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==,
+      }
+    engines: { node: ">= 10" }
+    cpu: [x64]
+    os: [darwin]
+
+  "@next/swc-darwin-x64@16.2.3":
+    resolution:
+      {
+        integrity: sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==,
       }
     engines: { node: ">= 10" }
     cpu: [x64]
@@ -1903,10 +2188,28 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  "@next/swc-linux-arm64-gnu@16.2.3":
+    resolution:
+      {
+        integrity: sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==,
+      }
+    engines: { node: ">= 10" }
+    cpu: [arm64]
+    os: [linux]
+
   "@next/swc-linux-arm64-musl@16.1.6":
     resolution:
       {
         integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==,
+      }
+    engines: { node: ">= 10" }
+    cpu: [arm64]
+    os: [linux]
+
+  "@next/swc-linux-arm64-musl@16.2.3":
+    resolution:
+      {
+        integrity: sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==,
       }
     engines: { node: ">= 10" }
     cpu: [arm64]
@@ -1921,10 +2224,28 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  "@next/swc-linux-x64-gnu@16.2.3":
+    resolution:
+      {
+        integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==,
+      }
+    engines: { node: ">= 10" }
+    cpu: [x64]
+    os: [linux]
+
   "@next/swc-linux-x64-musl@16.1.6":
     resolution:
       {
         integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==,
+      }
+    engines: { node: ">= 10" }
+    cpu: [x64]
+    os: [linux]
+
+  "@next/swc-linux-x64-musl@16.2.3":
+    resolution:
+      {
+        integrity: sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==,
       }
     engines: { node: ">= 10" }
     cpu: [x64]
@@ -1939,10 +2260,28 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  "@next/swc-win32-arm64-msvc@16.2.3":
+    resolution:
+      {
+        integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==,
+      }
+    engines: { node: ">= 10" }
+    cpu: [arm64]
+    os: [win32]
+
   "@next/swc-win32-x64-msvc@16.1.6":
     resolution:
       {
         integrity: sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==,
+      }
+    engines: { node: ">= 10" }
+    cpu: [x64]
+    os: [win32]
+
+  "@next/swc-win32-x64-msvc@16.2.3":
+    resolution:
+      {
+        integrity: sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==,
       }
     engines: { node: ">= 10" }
     cpu: [x64]
@@ -2855,6 +3194,264 @@ packages:
         integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==,
       }
 
+  "@react-email/body@0.3.0":
+    resolution:
+      {
+        integrity: sha512-uGo0BOOzjbMUo3lu+BIDWayvn5o6Xyfmnlla5VGf05n8gHMvO1ll7U4FtzWe3hxMLwt53pmc4iE0M+B5slG+Ug==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/button@0.2.1":
+    resolution:
+      {
+        integrity: sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/code-block@0.2.1":
+    resolution:
+      {
+        integrity: sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/code-inline@0.0.6":
+    resolution:
+      {
+        integrity: sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/column@0.0.14":
+    resolution:
+      {
+        integrity: sha512-f+W+Bk2AjNO77zynE33rHuQhyqVICx4RYtGX9NKsGUg0wWjdGP0qAuIkhx9Rnmk4/hFMo1fUrtYNqca9fwJdHg==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/components@1.0.12":
+    resolution:
+      {
+        integrity: sha512-tH18JhPDWgE+3jnYkzyB6ZrZdfNnEsFe4PwmuXmlOw4NGIysP8wPY5aXZg++pTG9qUabXg1nzX/FGHGkObH8xQ==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/container@0.0.16":
+    resolution:
+      {
+        integrity: sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/font@0.0.10":
+    resolution:
+      {
+        integrity: sha512-0urVSgCmQIfx5r7Xc586miBnQUVnGp3OTYUm8m5pwtQRdTRO5XrTtEfNJ3JhYhSOruV0nD8fd+dXtKXobum6tA==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/head@0.0.13":
+    resolution:
+      {
+        integrity: sha512-AJg6le/08Gz4tm+6MtKXqtNNyKHzmooOCdmtqmWxD7FxoAdU1eVcizhtQ0gcnVaY6ethEyE/hnEzQxt1zu5Kog==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/heading@0.0.16":
+    resolution:
+      {
+        integrity: sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/hr@0.0.12":
+    resolution:
+      {
+        integrity: sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/html@0.0.12":
+    resolution:
+      {
+        integrity: sha512-KTShZesan+UsreU7PDUV90afrZwU5TLwYlALuCSU0OT+/U8lULNNbAUekg+tGwCnOfIKYtpDPKkAMRdYlqUznw==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/img@0.0.12":
+    resolution:
+      {
+        integrity: sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/link@0.0.13":
+    resolution:
+      {
+        integrity: sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/markdown@0.0.18":
+    resolution:
+      {
+        integrity: sha512-gSuYK5fsMbGk87jDebqQ6fa2fKcWlkf2Dkva8kMONqLgGCq8/0d+ZQYMEJsdidIeBo3kmsnHZPrwdFB4HgjUXg==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/preview@0.0.14":
+    resolution:
+      {
+        integrity: sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/render@2.0.6":
+    resolution:
+      {
+        integrity: sha512-xOzaYkH3jLZKqN5MqrTXYnmqBYUnZSVbkxdb5PGGmDcK6sKDVMliaDiSwfXajRC9JtSHTcGc2tmGLHWuCgVpog==,
+      }
+    engines: { node: ">=20.0.0" }
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/render@2.0.8":
+    resolution:
+      {
+        integrity: sha512-5udvVr3U/WuGJZfLdLBOhkzrqRWd2Q5ZYmF7ppcy7FzWcwgshdqLMNqJOXcVzAXJXg/2bm7D+WGJzTtZOZMQnQ==,
+      }
+    engines: { node: ">=20.0.0" }
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/row@0.0.13":
+    resolution:
+      {
+        integrity: sha512-bYnOac40vIKCId7IkwuLAAsa3fKfSfqCvv6epJKmPE0JBuu5qI4FHFCl9o9dVpIIS08s/ub+Y/txoMt0dYziGw==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/section@0.0.17":
+    resolution:
+      {
+        integrity: sha512-qNl65ye3W0Rd5udhdORzTV9ezjb+GFqQQSae03NDzXtmJq6sqVXNWNiVolAjvJNypim+zGXmv6J9TcV5aNtE/w==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/tailwind@2.0.7":
+    resolution:
+      {
+        integrity: sha512-kGw80weVFXikcnCXbigTGXGWQ0MRCSYNCudcdkWxebkWYd0FG6/NPoN3V1p/u68/4+NxZwYPVi2fhnp0x23HdA==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      "@react-email/body": ">=0"
+      "@react-email/button": ">=0"
+      "@react-email/code-block": ">=0"
+      "@react-email/code-inline": ">=0"
+      "@react-email/container": ">=0"
+      "@react-email/heading": ">=0"
+      "@react-email/hr": ">=0"
+      "@react-email/img": ">=0"
+      "@react-email/link": ">=0"
+      "@react-email/preview": ">=0"
+      "@react-email/text": ">=0"
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      "@react-email/body":
+        optional: true
+      "@react-email/button":
+        optional: true
+      "@react-email/code-block":
+        optional: true
+      "@react-email/code-inline":
+        optional: true
+      "@react-email/container":
+        optional: true
+      "@react-email/heading":
+        optional: true
+      "@react-email/hr":
+        optional: true
+      "@react-email/img":
+        optional: true
+      "@react-email/link":
+        optional: true
+      "@react-email/preview":
+        optional: true
+
+  "@react-email/text@0.1.6":
+    resolution:
+      {
+        integrity: sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw==,
+      }
+    engines: { node: ">=20.0.0" }
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  "@react-email/ui@6.0.8":
+    resolution:
+      {
+        integrity: sha512-IG4uGzgb3FTONfehfsaBOlvaWoxcDFvJujNZMIIHiuVXYizJFy4I9+wyewQuiYTi44RArX7xvTFgGOeyXqj/xQ==,
+      }
+
   "@rtsao/scc@1.1.0":
     resolution:
       {
@@ -2865,6 +3462,12 @@ packages:
     resolution:
       {
         integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==,
+      }
+
+  "@selderee/plugin-htmlparser2@0.11.0":
+    resolution:
+      {
+        integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==,
       }
 
   "@simple-libs/stream-utils@1.2.0":
@@ -2887,6 +3490,12 @@ packages:
         integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==,
       }
     engines: { node: ">=18" }
+
+  "@socket.io/component-emitter@3.1.2":
+    resolution:
+      {
+        integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==,
+      }
 
   "@solvro/config@2.3.0":
     resolution:
@@ -3016,6 +3625,12 @@ packages:
         integrity: sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==,
       }
 
+  "@types/cors@2.8.19":
+    resolution:
+      {
+        integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==,
+      }
+
   "@types/crypto-js@4.2.2":
     resolution:
       {
@@ -3106,6 +3721,12 @@ packages:
     resolution:
       {
         integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==,
+      }
+
+  "@types/ws@8.18.1":
+    resolution:
+      {
+        integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==,
       }
 
   "@typescript-eslint/eslint-plugin@8.56.1":
@@ -3209,6 +3830,13 @@ packages:
         integrity: sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==,
       }
 
+  accepts@1.3.8:
+    resolution:
+      {
+        integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==,
+      }
+    engines: { node: ">= 0.6" }
+
   acorn-jsx@5.3.2:
     resolution:
       {
@@ -3225,10 +3853,27 @@ packages:
     engines: { node: ">=0.4.0" }
     hasBin: true
 
+  ajv-formats@3.0.1:
+    resolution:
+      {
+        integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==,
+      }
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.14.0:
     resolution:
       {
         integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==,
+      }
+
+  ajv@8.20.0:
+    resolution:
+      {
+        integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==,
       }
 
   ansi-styles@4.3.0:
@@ -3359,6 +4004,12 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  atomically@2.1.1:
+    resolution:
+      {
+        integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==,
+      }
+
   available-typed-arrays@1.0.7:
     resolution:
       {
@@ -3399,6 +4050,13 @@ packages:
         integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==,
       }
     engines: { node: 18 || 20 || >=22 }
+
+  base64id@2.0.0:
+    resolution:
+      {
+        integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==,
+      }
+    engines: { node: ^4.5.0 || >= 5.9 }
 
   baseline-browser-mapping@2.10.0:
     resolution:
@@ -3660,10 +4318,10 @@ packages:
         integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==,
       }
 
-  citty@0.2.1:
+  citty@0.2.2:
     resolution:
       {
-        integrity: sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==,
+        integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==,
       }
 
   class-validator@0.15.1:
@@ -3740,6 +4398,13 @@ packages:
       }
     engines: { node: ">=12.5.0" }
 
+  commander@13.1.0:
+    resolution:
+      {
+        integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==,
+      }
+    engines: { node: ">=18" }
+
   commander@14.0.3:
     resolution:
       {
@@ -3772,6 +4437,13 @@ packages:
       {
         integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
       }
+
+  conf@15.1.0:
+    resolution:
+      {
+        integrity: sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==,
+      }
+    engines: { node: ">=20" }
 
   confbox@0.1.8:
     resolution:
@@ -3813,6 +4485,13 @@ packages:
         integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
       }
 
+  cookie@0.7.2:
+    resolution:
+      {
+        integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==,
+      }
+    engines: { node: ">= 0.6" }
+
   copy-to-clipboard@3.3.3:
     resolution:
       {
@@ -3824,6 +4503,13 @@ packages:
       {
         integrity: sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==,
       }
+
+  cors@2.8.6:
+    resolution:
+      {
+        integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==,
+      }
+    engines: { node: ">= 0.10" }
 
   cross-spawn@7.0.6:
     resolution:
@@ -3850,6 +4536,13 @@ packages:
         integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==,
       }
     engines: { node: ">=8.0.0" }
+
+  css-tree@3.2.1:
+    resolution:
+      {
+        integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==,
+      }
+    engines: { node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0 }
 
   cssesc@3.0.0:
     resolution:
@@ -3898,6 +4591,20 @@ packages:
         integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==,
       }
 
+  debounce-fn@6.0.0:
+    resolution:
+      {
+        integrity: sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==,
+      }
+    engines: { node: ">=18" }
+
+  debounce@2.2.0:
+    resolution:
+      {
+        integrity: sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==,
+      }
+    engines: { node: ">=18" }
+
   debug@3.2.7:
     resolution:
       {
@@ -3933,6 +4640,13 @@ packages:
         integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==,
       }
     engines: { node: ">=16.0.0" }
+
+  deepmerge@4.3.1:
+    resolution:
+      {
+        integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==,
+      }
+    engines: { node: ">=0.10.0" }
 
   define-data-property@1.1.4:
     resolution:
@@ -4012,6 +4726,38 @@ packages:
         integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==,
       }
     engines: { node: ">=0.10.0" }
+
+  dom-serializer@2.0.0:
+    resolution:
+      {
+        integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==,
+      }
+
+  domelementtype@2.3.0:
+    resolution:
+      {
+        integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==,
+      }
+
+  domhandler@5.0.3:
+    resolution:
+      {
+        integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==,
+      }
+    engines: { node: ">= 4" }
+
+  domutils@3.2.2:
+    resolution:
+      {
+        integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==,
+      }
+
+  dot-prop@10.1.0:
+    resolution:
+      {
+        integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==,
+      }
+    engines: { node: ">=20" }
 
   dot-prop@5.3.0:
     resolution:
@@ -4168,12 +4914,40 @@ packages:
       }
     engines: { node: ">=14" }
 
+  engine.io-parser@5.2.3:
+    resolution:
+      {
+        integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==,
+      }
+    engines: { node: ">=10.0.0" }
+
+  engine.io@6.6.7:
+    resolution:
+      {
+        integrity: sha512-DgOngfDKM2EviOH3Mr9m7ks1q8roetLy/IMmYthAYzbpInMbYc/GS+fWFA3rl1gvwKVsQrVV61fo5emD1y3OJQ==,
+      }
+    engines: { node: ">=10.2.0" }
+
   enhanced-resolve@5.20.0:
     resolution:
       {
         integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==,
       }
     engines: { node: ">=10.13.0" }
+
+  entities@4.5.0:
+    resolution:
+      {
+        integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==,
+      }
+    engines: { node: ">=0.12" }
+
+  env-paths@3.0.0:
+    resolution:
+      {
+        integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
   error-stack-parser@2.1.4:
     resolution:
@@ -4265,6 +5039,14 @@ packages:
     resolution:
       {
         integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution:
+      {
+        integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==,
       }
     engines: { node: ">=18" }
     hasBin: true
@@ -4623,6 +5405,12 @@ packages:
         integrity: sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==,
       }
 
+  fast-uri@3.1.1:
+    resolution:
+      {
+        integrity: sha512-h2r7rcm6Ee/J8o0LD5djLuFVcfbZxhvho4vvsbeV0aMvXjUgqv4YpxpkEx0d68l6+IleVfLAdVEfhR7QNMkGHQ==,
+      }
+
   fastest-stable-stringify@2.0.2:
     resolution:
       {
@@ -4868,6 +5656,20 @@ packages:
       }
     engines: { node: 20 || >=22 }
 
+  glob@13.0.6:
+    resolution:
+      {
+        integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==,
+      }
+    engines: { node: 18 || 20 || >=22 }
+
+  globals@11.12.0:
+    resolution:
+      {
+        integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==,
+      }
+    engines: { node: ">=4" }
+
   globals@14.0.0:
     resolution:
       {
@@ -5018,6 +5820,19 @@ packages:
     resolution:
       {
         integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==,
+      }
+
+  html-to-text@9.0.5:
+    resolution:
+      {
+        integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==,
+      }
+    engines: { node: ">=14" }
+
+  htmlparser2@8.0.2:
+    resolution:
+      {
+        integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==,
       }
 
   http-status-codes@2.3.0:
@@ -5385,6 +6200,13 @@ packages:
       }
     hasBin: true
 
+  jiti@2.4.2:
+    resolution:
+      {
+        integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==,
+      }
+    hasBin: true
+
   jiti@2.6.1:
     resolution:
       {
@@ -5474,6 +6296,18 @@ packages:
         integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==,
       }
 
+  json-schema-traverse@1.0.0:
+    resolution:
+      {
+        integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==,
+      }
+
+  json-schema-typed@8.0.2:
+    resolution:
+      {
+        integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==,
+      }
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution:
       {
@@ -5508,6 +6342,13 @@ packages:
         integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==,
       }
 
+  kleur@3.0.3:
+    resolution:
+      {
+        integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==,
+      }
+    engines: { node: ">=6" }
+
   knip@5.86.0:
     resolution:
       {
@@ -5538,6 +6379,12 @@ packages:
         integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==,
       }
     engines: { node: ">=0.10" }
+
+  leac@0.6.0:
+    resolution:
+      {
+        integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==,
+      }
 
   levn@0.4.1:
     resolution:
@@ -5616,6 +6463,13 @@ packages:
         integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==,
       }
 
+  log-symbols@7.0.1:
+    resolution:
+      {
+        integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==,
+      }
+    engines: { node: ">=18" }
+
   long@5.3.2:
     resolution:
       {
@@ -5657,6 +6511,14 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
 
+  marked@15.0.12:
+    resolution:
+      {
+        integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==,
+      }
+    engines: { node: ">= 18" }
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution:
       {
@@ -5668,6 +6530,12 @@ packages:
     resolution:
       {
         integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==,
+      }
+
+  mdn-data@2.27.1:
+    resolution:
+      {
+        integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==,
       }
 
   memory-pager@1.5.0:
@@ -5696,6 +6564,41 @@ packages:
         integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==,
       }
     engines: { node: ">=8.6" }
+
+  mime-db@1.52.0:
+    resolution:
+      {
+        integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==,
+      }
+    engines: { node: ">= 0.6" }
+
+  mime-db@1.54.0:
+    resolution:
+      {
+        integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==,
+      }
+    engines: { node: ">= 0.6" }
+
+  mime-types@2.1.35:
+    resolution:
+      {
+        integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==,
+      }
+    engines: { node: ">= 0.6" }
+
+  mime-types@3.0.2:
+    resolution:
+      {
+        integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==,
+      }
+    engines: { node: ">=18" }
+
+  mimic-function@5.0.1:
+    resolution:
+      {
+        integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==,
+      }
+    engines: { node: ">=18" }
 
   minimatch@10.2.4:
     resolution:
@@ -5858,6 +6761,13 @@ packages:
         integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==,
       }
 
+  negotiator@0.6.3:
+    resolution:
+      {
+        integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==,
+      }
+    engines: { node: ">= 0.6" }
+
   next-themes@0.4.6:
     resolution:
       {
@@ -5871,6 +6781,30 @@ packages:
     resolution:
       {
         integrity: sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==,
+      }
+    engines: { node: ">=20.9.0" }
+    hasBin: true
+    peerDependencies:
+      "@opentelemetry/api": ^1.1.0
+      "@playwright/test": ^1.51.1
+      babel-plugin-react-compiler: "*"
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      "@opentelemetry/api":
+        optional: true
+      "@playwright/test":
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
+  next@16.2.3:
+    resolution:
+      {
+        integrity: sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==,
       }
     engines: { node: ">=20.9.0" }
     hasBin: true
@@ -5938,10 +6872,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  nypm@0.6.5:
+  nypm@0.6.6:
     resolution:
       {
-        integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==,
+        integrity: sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==,
       }
     engines: { node: ">=18" }
     hasBin: true
@@ -6100,6 +7034,12 @@ packages:
         integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==,
       }
 
+  parseley@0.12.1:
+    resolution:
+      {
+        integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==,
+      }
+
   path-exists@4.0.0:
     resolution:
       {
@@ -6138,6 +7078,12 @@ packages:
     resolution:
       {
         integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
+      }
+
+  peberminta@0.9.0:
+    resolution:
+      {
+        integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==,
       }
 
   perfect-debounce@1.0.0:
@@ -6223,6 +7169,13 @@ packages:
         integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==,
       }
     engines: { node: ">=12" }
+
+  picospinner@3.0.0:
+    resolution:
+      {
+        integrity: sha512-lGA1TNsmy2bxvRsTI2cV01kfTwKzZjnZSDmF9llYNyMHMrU4sP87lQ5taiIKm88L3cbswjl008nwyGc3WpNvzg==,
+      }
+    engines: { node: ">=18.0.0" }
 
   pify@2.3.0:
     resolution:
@@ -6488,6 +7441,20 @@ packages:
       typescript:
         optional: true
 
+  prismjs@1.30.0:
+    resolution:
+      {
+        integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==,
+      }
+    engines: { node: ">=6" }
+
+  prompts@2.4.2:
+    resolution:
+      {
+        integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==,
+      }
+    engines: { node: ">= 6" }
+
   prop-types@15.8.1:
     resolution:
       {
@@ -6538,6 +7505,17 @@ packages:
       }
     peerDependencies:
       react: ^19.2.4
+
+  react-email@6.0.8:
+    resolution:
+      {
+        integrity: sha512-/kArasUY1ahkrs8z8OG0wz+d7hedV/wUSZ8qaXI2TtB6omUMmMtm//FBHSSdnsEvkUnAZ5LzCyge1h6oQNhpTA==,
+      }
+    engines: { node: ">=20.0.0" }
+    hasBin: true
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
 
   react-hook-form@7.71.2:
     resolution:
@@ -6720,6 +7698,13 @@ packages:
         integrity: sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==,
       }
 
+  require-from-string@2.0.2:
+    resolution:
+      {
+        integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==,
+      }
+    engines: { node: ">=0.10.0" }
+
   reserved-identifiers@1.2.0:
     resolution:
       {
@@ -6833,6 +7818,12 @@ packages:
         integrity: sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==,
       }
     engines: { node: ">=0.10.0" }
+
+  selderee@0.11.0:
+    resolution:
+      {
+        integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==,
+      }
 
   semver@6.3.1:
     resolution:
@@ -6976,6 +7967,26 @@ packages:
         integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==,
       }
     engines: { node: ">= 18" }
+
+  socket.io-adapter@2.5.6:
+    resolution:
+      {
+        integrity: sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==,
+      }
+
+  socket.io-parser@4.2.6:
+    resolution:
+      {
+        integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==,
+      }
+    engines: { node: ">=10.0.0" }
+
+  socket.io@4.8.3:
+    resolution:
+      {
+        integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==,
+      }
+    engines: { node: ">=10.2.0" }
 
   sonner@1.7.4:
     resolution:
@@ -7196,6 +8207,18 @@ packages:
       }
     engines: { node: ">=14.16" }
 
+  stubborn-fs@2.0.0:
+    resolution:
+      {
+        integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==,
+      }
+
+  stubborn-utils@1.0.2:
+    resolution:
+      {
+        integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==,
+      }
+
   styled-jsx@5.1.6:
     resolution:
       {
@@ -7285,6 +8308,12 @@ packages:
     engines: { node: ">=14.0.0" }
     hasBin: true
 
+  tailwindcss@4.2.4:
+    resolution:
+      {
+        integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==,
+      }
+
   tapable@2.3.0:
     resolution:
       {
@@ -7312,10 +8341,10 @@ packages:
       }
     engines: { node: ">=10" }
 
-  tinyexec@1.0.2:
+  tinyexec@1.1.2:
     resolution:
       {
-        integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==,
+        integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==,
       }
     engines: { node: ">=18" }
 
@@ -7387,6 +8416,13 @@ packages:
       {
         integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==,
       }
+
+  tsconfig-paths@4.2.0:
+    resolution:
+      {
+        integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==,
+      }
+    engines: { node: ">=6" }
 
   tslib@2.8.1:
     resolution:
@@ -7474,6 +8510,13 @@ packages:
       {
         integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==,
       }
+
+  uint8array-extras@1.5.0:
+    resolution:
+      {
+        integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==,
+      }
+    engines: { node: ">=18" }
 
   unbash@2.2.0:
     resolution:
@@ -7601,6 +8644,13 @@ packages:
       }
     engines: { node: ">= 0.10" }
 
+  vary@1.1.2:
+    resolution:
+      {
+        integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==,
+      }
+    engines: { node: ">= 0.8" }
+
   vaul@0.9.9:
     resolution:
       {
@@ -7630,6 +8680,12 @@ packages:
         integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==,
       }
     engines: { node: ">=18" }
+
+  when-exit@2.1.5:
+    resolution:
+      {
+        integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==,
+      }
 
   which-boxed-primitive@1.1.1:
     resolution:
@@ -7673,6 +8729,21 @@ packages:
         integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==,
       }
     engines: { node: ">=0.10.0" }
+
+  ws@8.18.3:
+    resolution:
+      {
+        integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==,
+      }
+    engines: { node: ">=10.0.0" }
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ">=5.0.2"
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xtend@4.0.2:
     resolution:
@@ -7831,6 +8902,10 @@ snapshots:
       "@babel/template": 7.28.6
       "@babel/types": 7.29.0
 
+  "@babel/parser@7.27.0":
+    dependencies:
+      "@babel/types": 7.29.0
+
   "@babel/parser@7.29.0":
     dependencies:
       "@babel/types": 7.29.0
@@ -7842,6 +8917,18 @@ snapshots:
       "@babel/code-frame": 7.29.0
       "@babel/parser": 7.29.0
       "@babel/types": 7.29.0
+
+  "@babel/traverse@7.27.0":
+    dependencies:
+      "@babel/code-frame": 7.29.0
+      "@babel/generator": 7.29.1
+      "@babel/parser": 7.29.0
+      "@babel/template": 7.28.6
+      "@babel/types": 7.29.0
+      debug: 4.4.3
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
 
   "@babel/traverse@7.29.0":
     dependencies:
@@ -8018,6 +9105,9 @@ snapshots:
   "@esbuild/aix-ppc64@0.27.3":
     optional: true
 
+  "@esbuild/aix-ppc64@0.28.0":
+    optional: true
+
   "@esbuild/android-arm64@0.18.20":
     optional: true
 
@@ -8025,6 +9115,9 @@ snapshots:
     optional: true
 
   "@esbuild/android-arm64@0.27.3":
+    optional: true
+
+  "@esbuild/android-arm64@0.28.0":
     optional: true
 
   "@esbuild/android-arm@0.18.20":
@@ -8036,6 +9129,9 @@ snapshots:
   "@esbuild/android-arm@0.27.3":
     optional: true
 
+  "@esbuild/android-arm@0.28.0":
+    optional: true
+
   "@esbuild/android-x64@0.18.20":
     optional: true
 
@@ -8043,6 +9139,9 @@ snapshots:
     optional: true
 
   "@esbuild/android-x64@0.27.3":
+    optional: true
+
+  "@esbuild/android-x64@0.28.0":
     optional: true
 
   "@esbuild/darwin-arm64@0.18.20":
@@ -8054,6 +9153,9 @@ snapshots:
   "@esbuild/darwin-arm64@0.27.3":
     optional: true
 
+  "@esbuild/darwin-arm64@0.28.0":
+    optional: true
+
   "@esbuild/darwin-x64@0.18.20":
     optional: true
 
@@ -8061,6 +9163,9 @@ snapshots:
     optional: true
 
   "@esbuild/darwin-x64@0.27.3":
+    optional: true
+
+  "@esbuild/darwin-x64@0.28.0":
     optional: true
 
   "@esbuild/freebsd-arm64@0.18.20":
@@ -8072,6 +9177,9 @@ snapshots:
   "@esbuild/freebsd-arm64@0.27.3":
     optional: true
 
+  "@esbuild/freebsd-arm64@0.28.0":
+    optional: true
+
   "@esbuild/freebsd-x64@0.18.20":
     optional: true
 
@@ -8079,6 +9187,9 @@ snapshots:
     optional: true
 
   "@esbuild/freebsd-x64@0.27.3":
+    optional: true
+
+  "@esbuild/freebsd-x64@0.28.0":
     optional: true
 
   "@esbuild/linux-arm64@0.18.20":
@@ -8090,6 +9201,9 @@ snapshots:
   "@esbuild/linux-arm64@0.27.3":
     optional: true
 
+  "@esbuild/linux-arm64@0.28.0":
+    optional: true
+
   "@esbuild/linux-arm@0.18.20":
     optional: true
 
@@ -8097,6 +9211,9 @@ snapshots:
     optional: true
 
   "@esbuild/linux-arm@0.27.3":
+    optional: true
+
+  "@esbuild/linux-arm@0.28.0":
     optional: true
 
   "@esbuild/linux-ia32@0.18.20":
@@ -8108,6 +9225,9 @@ snapshots:
   "@esbuild/linux-ia32@0.27.3":
     optional: true
 
+  "@esbuild/linux-ia32@0.28.0":
+    optional: true
+
   "@esbuild/linux-loong64@0.18.20":
     optional: true
 
@@ -8115,6 +9235,9 @@ snapshots:
     optional: true
 
   "@esbuild/linux-loong64@0.27.3":
+    optional: true
+
+  "@esbuild/linux-loong64@0.28.0":
     optional: true
 
   "@esbuild/linux-mips64el@0.18.20":
@@ -8126,6 +9249,9 @@ snapshots:
   "@esbuild/linux-mips64el@0.27.3":
     optional: true
 
+  "@esbuild/linux-mips64el@0.28.0":
+    optional: true
+
   "@esbuild/linux-ppc64@0.18.20":
     optional: true
 
@@ -8133,6 +9259,9 @@ snapshots:
     optional: true
 
   "@esbuild/linux-ppc64@0.27.3":
+    optional: true
+
+  "@esbuild/linux-ppc64@0.28.0":
     optional: true
 
   "@esbuild/linux-riscv64@0.18.20":
@@ -8144,6 +9273,9 @@ snapshots:
   "@esbuild/linux-riscv64@0.27.3":
     optional: true
 
+  "@esbuild/linux-riscv64@0.28.0":
+    optional: true
+
   "@esbuild/linux-s390x@0.18.20":
     optional: true
 
@@ -8151,6 +9283,9 @@ snapshots:
     optional: true
 
   "@esbuild/linux-s390x@0.27.3":
+    optional: true
+
+  "@esbuild/linux-s390x@0.28.0":
     optional: true
 
   "@esbuild/linux-x64@0.18.20":
@@ -8162,10 +9297,16 @@ snapshots:
   "@esbuild/linux-x64@0.27.3":
     optional: true
 
+  "@esbuild/linux-x64@0.28.0":
+    optional: true
+
   "@esbuild/netbsd-arm64@0.25.12":
     optional: true
 
   "@esbuild/netbsd-arm64@0.27.3":
+    optional: true
+
+  "@esbuild/netbsd-arm64@0.28.0":
     optional: true
 
   "@esbuild/netbsd-x64@0.18.20":
@@ -8177,10 +9318,16 @@ snapshots:
   "@esbuild/netbsd-x64@0.27.3":
     optional: true
 
+  "@esbuild/netbsd-x64@0.28.0":
+    optional: true
+
   "@esbuild/openbsd-arm64@0.25.12":
     optional: true
 
   "@esbuild/openbsd-arm64@0.27.3":
+    optional: true
+
+  "@esbuild/openbsd-arm64@0.28.0":
     optional: true
 
   "@esbuild/openbsd-x64@0.18.20":
@@ -8192,10 +9339,16 @@ snapshots:
   "@esbuild/openbsd-x64@0.27.3":
     optional: true
 
+  "@esbuild/openbsd-x64@0.28.0":
+    optional: true
+
   "@esbuild/openharmony-arm64@0.25.12":
     optional: true
 
   "@esbuild/openharmony-arm64@0.27.3":
+    optional: true
+
+  "@esbuild/openharmony-arm64@0.28.0":
     optional: true
 
   "@esbuild/sunos-x64@0.18.20":
@@ -8207,6 +9360,9 @@ snapshots:
   "@esbuild/sunos-x64@0.27.3":
     optional: true
 
+  "@esbuild/sunos-x64@0.28.0":
+    optional: true
+
   "@esbuild/win32-arm64@0.18.20":
     optional: true
 
@@ -8214,6 +9370,9 @@ snapshots:
     optional: true
 
   "@esbuild/win32-arm64@0.27.3":
+    optional: true
+
+  "@esbuild/win32-arm64@0.28.0":
     optional: true
 
   "@esbuild/win32-ia32@0.18.20":
@@ -8225,6 +9384,9 @@ snapshots:
   "@esbuild/win32-ia32@0.27.3":
     optional: true
 
+  "@esbuild/win32-ia32@0.28.0":
+    optional: true
+
   "@esbuild/win32-x64@0.18.20":
     optional: true
 
@@ -8232,6 +9394,9 @@ snapshots:
     optional: true
 
   "@esbuild/win32-x64@0.27.3":
+    optional: true
+
+  "@esbuild/win32-x64@0.28.0":
     optional: true
 
   "@eslint-community/eslint-plugin-eslint-comments@4.7.1(eslint@9.39.4(jiti@1.21.7))":
@@ -8544,6 +9709,8 @@ snapshots:
 
   "@next/env@16.1.6": {}
 
+  "@next/env@16.2.3": {}
+
   "@next/eslint-plugin-next@16.2.1":
     dependencies:
       fast-glob: 3.3.1
@@ -8551,25 +9718,49 @@ snapshots:
   "@next/swc-darwin-arm64@16.1.6":
     optional: true
 
+  "@next/swc-darwin-arm64@16.2.3":
+    optional: true
+
   "@next/swc-darwin-x64@16.1.6":
+    optional: true
+
+  "@next/swc-darwin-x64@16.2.3":
     optional: true
 
   "@next/swc-linux-arm64-gnu@16.1.6":
     optional: true
 
+  "@next/swc-linux-arm64-gnu@16.2.3":
+    optional: true
+
   "@next/swc-linux-arm64-musl@16.1.6":
+    optional: true
+
+  "@next/swc-linux-arm64-musl@16.2.3":
     optional: true
 
   "@next/swc-linux-x64-gnu@16.1.6":
     optional: true
 
+  "@next/swc-linux-x64-gnu@16.2.3":
+    optional: true
+
   "@next/swc-linux-x64-musl@16.1.6":
+    optional: true
+
+  "@next/swc-linux-x64-musl@16.2.3":
     optional: true
 
   "@next/swc-win32-arm64-msvc@16.1.6":
     optional: true
 
+  "@next/swc-win32-arm64-msvc@16.2.3":
+    optional: true
+
   "@next/swc-win32-x64-msvc@16.1.6":
+    optional: true
+
+  "@next/swc-win32-x64-msvc@16.2.3":
     optional: true
 
   "@noble/ciphers@2.1.1": {}
@@ -9207,15 +10398,167 @@ snapshots:
 
   "@radix-ui/rect@1.1.1": {}
 
+  "@react-email/body@0.3.0(react@19.2.4)":
+    dependencies:
+      react: 19.2.4
+
+  "@react-email/button@0.2.1(react@19.2.4)":
+    dependencies:
+      react: 19.2.4
+
+  "@react-email/code-block@0.2.1(react@19.2.4)":
+    dependencies:
+      prismjs: 1.30.0
+      react: 19.2.4
+
+  "@react-email/code-inline@0.0.6(react@19.2.4)":
+    dependencies:
+      react: 19.2.4
+
+  "@react-email/column@0.0.14(react@19.2.4)":
+    dependencies:
+      react: 19.2.4
+
+  "@react-email/components@1.0.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)":
+    dependencies:
+      "@react-email/body": 0.3.0(react@19.2.4)
+      "@react-email/button": 0.2.1(react@19.2.4)
+      "@react-email/code-block": 0.2.1(react@19.2.4)
+      "@react-email/code-inline": 0.0.6(react@19.2.4)
+      "@react-email/column": 0.0.14(react@19.2.4)
+      "@react-email/container": 0.0.16(react@19.2.4)
+      "@react-email/font": 0.0.10(react@19.2.4)
+      "@react-email/head": 0.0.13(react@19.2.4)
+      "@react-email/heading": 0.0.16(react@19.2.4)
+      "@react-email/hr": 0.0.12(react@19.2.4)
+      "@react-email/html": 0.0.12(react@19.2.4)
+      "@react-email/img": 0.0.12(react@19.2.4)
+      "@react-email/link": 0.0.13(react@19.2.4)
+      "@react-email/markdown": 0.0.18(react@19.2.4)
+      "@react-email/preview": 0.0.14(react@19.2.4)
+      "@react-email/render": 2.0.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      "@react-email/row": 0.0.13(react@19.2.4)
+      "@react-email/section": 0.0.17(react@19.2.4)
+      "@react-email/tailwind": 2.0.7(@react-email/body@0.3.0(react@19.2.4))(@react-email/button@0.2.1(react@19.2.4))(@react-email/code-block@0.2.1(react@19.2.4))(@react-email/code-inline@0.0.6(react@19.2.4))(@react-email/container@0.0.16(react@19.2.4))(@react-email/heading@0.0.16(react@19.2.4))(@react-email/hr@0.0.12(react@19.2.4))(@react-email/img@0.0.12(react@19.2.4))(@react-email/link@0.0.13(react@19.2.4))(@react-email/preview@0.0.14(react@19.2.4))(@react-email/text@0.1.6(react@19.2.4))(react@19.2.4)
+      "@react-email/text": 0.1.6(react@19.2.4)
+      react: 19.2.4
+    transitivePeerDependencies:
+      - react-dom
+
+  "@react-email/container@0.0.16(react@19.2.4)":
+    dependencies:
+      react: 19.2.4
+
+  "@react-email/font@0.0.10(react@19.2.4)":
+    dependencies:
+      react: 19.2.4
+
+  "@react-email/head@0.0.13(react@19.2.4)":
+    dependencies:
+      react: 19.2.4
+
+  "@react-email/heading@0.0.16(react@19.2.4)":
+    dependencies:
+      react: 19.2.4
+
+  "@react-email/hr@0.0.12(react@19.2.4)":
+    dependencies:
+      react: 19.2.4
+
+  "@react-email/html@0.0.12(react@19.2.4)":
+    dependencies:
+      react: 19.2.4
+
+  "@react-email/img@0.0.12(react@19.2.4)":
+    dependencies:
+      react: 19.2.4
+
+  "@react-email/link@0.0.13(react@19.2.4)":
+    dependencies:
+      react: 19.2.4
+
+  "@react-email/markdown@0.0.18(react@19.2.4)":
+    dependencies:
+      marked: 15.0.12
+      react: 19.2.4
+
+  "@react-email/preview@0.0.14(react@19.2.4)":
+    dependencies:
+      react: 19.2.4
+
+  "@react-email/render@2.0.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)":
+    dependencies:
+      html-to-text: 9.0.5
+      prettier: 3.8.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  "@react-email/render@2.0.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)":
+    dependencies:
+      html-to-text: 9.0.5
+      prettier: 3.8.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  "@react-email/row@0.0.13(react@19.2.4)":
+    dependencies:
+      react: 19.2.4
+
+  "@react-email/section@0.0.17(react@19.2.4)":
+    dependencies:
+      react: 19.2.4
+
+  "@react-email/tailwind@2.0.7(@react-email/body@0.3.0(react@19.2.4))(@react-email/button@0.2.1(react@19.2.4))(@react-email/code-block@0.2.1(react@19.2.4))(@react-email/code-inline@0.0.6(react@19.2.4))(@react-email/container@0.0.16(react@19.2.4))(@react-email/heading@0.0.16(react@19.2.4))(@react-email/hr@0.0.12(react@19.2.4))(@react-email/img@0.0.12(react@19.2.4))(@react-email/link@0.0.13(react@19.2.4))(@react-email/preview@0.0.14(react@19.2.4))(@react-email/text@0.1.6(react@19.2.4))(react@19.2.4)":
+    dependencies:
+      "@react-email/text": 0.1.6(react@19.2.4)
+      react: 19.2.4
+      tailwindcss: 4.2.4
+    optionalDependencies:
+      "@react-email/body": 0.3.0(react@19.2.4)
+      "@react-email/button": 0.2.1(react@19.2.4)
+      "@react-email/code-block": 0.2.1(react@19.2.4)
+      "@react-email/code-inline": 0.0.6(react@19.2.4)
+      "@react-email/container": 0.0.16(react@19.2.4)
+      "@react-email/heading": 0.0.16(react@19.2.4)
+      "@react-email/hr": 0.0.12(react@19.2.4)
+      "@react-email/img": 0.0.12(react@19.2.4)
+      "@react-email/link": 0.0.13(react@19.2.4)
+      "@react-email/preview": 0.0.14(react@19.2.4)
+
+  "@react-email/text@0.1.6(react@19.2.4)":
+    dependencies:
+      react: 19.2.4
+
+  "@react-email/ui@6.0.8(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)":
+    dependencies:
+      esbuild: 0.28.0
+      next: 16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+    transitivePeerDependencies:
+      - "@babel/core"
+      - "@opentelemetry/api"
+      - "@playwright/test"
+      - babel-plugin-macros
+      - babel-plugin-react-compiler
+      - react
+      - react-dom
+      - sass
+
   "@rtsao/scc@1.1.0": {}
 
   "@sec-ant/readable-stream@0.4.1": {}
+
+  "@selderee/plugin-htmlparser2@0.11.0":
+    dependencies:
+      domhandler: 5.0.3
+      selderee: 0.11.0
 
   "@simple-libs/stream-utils@1.2.0": {}
 
   "@sindresorhus/base62@1.0.0": {}
 
   "@sindresorhus/merge-streams@4.0.0": {}
+
+  "@socket.io/component-emitter@3.1.2": {}
 
   "@solvro/config@2.3.0(@next/eslint-plugin-next@16.2.1)(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(class-validator@0.15.1)(eslint@9.39.4(jiti@1.21.7))(prettier@3.8.1)(typescript@5.9.3)":
     dependencies:
@@ -9356,6 +10699,10 @@ snapshots:
 
   "@types/canvas-confetti@1.9.0": {}
 
+  "@types/cors@2.8.19":
+    dependencies:
+      "@types/node": 20.19.37
+
   "@types/crypto-js@4.2.2": {}
 
   "@types/estree@1.0.8": {}
@@ -9399,6 +10746,10 @@ snapshots:
   "@types/whatwg-url@13.0.0":
     dependencies:
       "@types/webidl-conversions": 7.0.3
+
+  "@types/ws@8.18.1":
+    dependencies:
+      "@types/node": 20.19.37
 
   "@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)":
     dependencies:
@@ -9498,11 +10849,20 @@ snapshots:
 
   "@xobotyi/scrollbar-width@1.9.5": {}
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
 
   ajv@6.14.0:
     dependencies:
@@ -9510,6 +10870,13 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.1
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-styles@4.3.0:
     dependencies:
@@ -9607,6 +10974,11 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  atomically@2.1.1:
+    dependencies:
+      stubborn-fs: 2.0.0
+      when-exit: 2.1.5
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -9620,6 +10992,8 @@ snapshots:
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  base64id@2.0.0: {}
 
   baseline-browser-mapping@2.10.0: {}
 
@@ -9783,7 +11157,7 @@ snapshots:
     dependencies:
       consola: 3.4.2
 
-  citty@0.2.1: {}
+  citty@0.2.2: {}
 
   class-validator@0.15.1:
     dependencies:
@@ -9833,6 +11207,8 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
 
+  commander@13.1.0: {}
+
   commander@14.0.3: {}
 
   commander@4.1.1: {}
@@ -9845,6 +11221,18 @@ snapshots:
       dot-prop: 5.3.0
 
   concat-map@0.0.1: {}
+
+  conf@15.1.0:
+    dependencies:
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      atomically: 2.1.1
+      debounce-fn: 6.0.0
+      dot-prop: 10.1.0
+      env-paths: 3.0.0
+      json-schema-typed: 8.0.2
+      semver: 7.7.4
+      uint8array-extras: 1.5.0
 
   confbox@0.1.8: {}
 
@@ -9863,6 +11251,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@0.7.2: {}
+
   copy-to-clipboard@3.3.3:
     dependencies:
       toggle-selection: 1.0.6
@@ -9870,6 +11260,11 @@ snapshots:
   core-js-compat@3.48.0:
     dependencies:
       browserslist: 4.28.1
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -9887,6 +11282,11 @@ snapshots:
     dependencies:
       mdn-data: 2.0.14
       source-map: 0.6.1
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
 
   cssesc@3.0.0: {}
 
@@ -9914,6 +11314,12 @@ snapshots:
 
   date-fns@4.1.0: {}
 
+  debounce-fn@6.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
+  debounce@2.2.0: {}
+
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -9925,6 +11331,8 @@ snapshots:
   deep-is@0.1.4: {}
 
   deepmerge-ts@7.1.5: {}
+
+  deepmerge@4.3.1: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -9959,6 +11367,28 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
+  dot-prop@10.1.0:
+    dependencies:
+      type-fest: 5.4.4
 
   dot-prop@5.3.0:
     dependencies:
@@ -10006,10 +11436,33 @@ snapshots:
 
   empathic@2.0.0: {}
 
+  engine.io-parser@5.2.3: {}
+
+  engine.io@6.6.7:
+    dependencies:
+      "@types/cors": 2.8.19
+      "@types/node": 20.19.37
+      "@types/ws": 8.18.1
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cookie: 0.7.2
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   enhanced-resolve@5.20.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  entities@4.5.0: {}
+
+  env-paths@3.0.0: {}
 
   error-stack-parser@2.1.4:
     dependencies:
@@ -10205,6 +11658,35 @@ snapshots:
       "@esbuild/win32-arm64": 0.27.3
       "@esbuild/win32-ia32": 0.27.3
       "@esbuild/win32-x64": 0.27.3
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      "@esbuild/aix-ppc64": 0.28.0
+      "@esbuild/android-arm": 0.28.0
+      "@esbuild/android-arm64": 0.28.0
+      "@esbuild/android-x64": 0.28.0
+      "@esbuild/darwin-arm64": 0.28.0
+      "@esbuild/darwin-x64": 0.28.0
+      "@esbuild/freebsd-arm64": 0.28.0
+      "@esbuild/freebsd-x64": 0.28.0
+      "@esbuild/linux-arm": 0.28.0
+      "@esbuild/linux-arm64": 0.28.0
+      "@esbuild/linux-ia32": 0.28.0
+      "@esbuild/linux-loong64": 0.28.0
+      "@esbuild/linux-mips64el": 0.28.0
+      "@esbuild/linux-ppc64": 0.28.0
+      "@esbuild/linux-riscv64": 0.28.0
+      "@esbuild/linux-s390x": 0.28.0
+      "@esbuild/linux-x64": 0.28.0
+      "@esbuild/netbsd-arm64": 0.28.0
+      "@esbuild/netbsd-x64": 0.28.0
+      "@esbuild/openbsd-arm64": 0.28.0
+      "@esbuild/openbsd-x64": 0.28.0
+      "@esbuild/openharmony-arm64": 0.28.0
+      "@esbuild/sunos-x64": 0.28.0
+      "@esbuild/win32-arm64": 0.28.0
+      "@esbuild/win32-ia32": 0.28.0
+      "@esbuild/win32-x64": 0.28.0
 
   escalade@3.2.0: {}
 
@@ -10538,6 +12020,8 @@ snapshots:
 
   fast-shallow-equal@1.0.0: {}
 
+  fast-uri@3.1.1: {}
+
   fastest-stable-stringify@2.0.2: {}
 
   fastq@1.20.1:
@@ -10667,7 +12151,7 @@ snapshots:
       consola: 3.4.2
       defu: 6.1.4
       node-fetch-native: 1.6.7
-      nypm: 0.6.5
+      nypm: 0.6.6
       pathe: 2.0.3
 
   git-hooks-list@4.2.1: {}
@@ -10685,6 +12169,14 @@ snapshots:
       minimatch: 10.2.4
       minipass: 7.1.3
       path-scurry: 2.0.2
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.4
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
+  globals@11.12.0: {}
 
   globals@14.0.0: {}
 
@@ -10746,6 +12238,21 @@ snapshots:
   html-entities@2.6.0: {}
 
   html-to-image@1.11.13: {}
+
+  html-to-text@9.0.5:
+    dependencies:
+      "@selderee/plugin-htmlparser2": 0.11.0
+      deepmerge: 4.3.1
+      dom-serializer: 2.0.0
+      htmlparser2: 8.0.2
+      selderee: 0.11.0
+
+  htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
 
   http-status-codes@2.3.0: {}
 
@@ -10948,6 +12455,8 @@ snapshots:
 
   jiti@1.21.7: {}
 
+  jiti@2.4.2: {}
+
   jiti@2.6.1: {}
 
   jose@6.2.0: {}
@@ -10979,6 +12488,10 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@1.0.2:
@@ -10997,6 +12510,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kleur@3.0.3: {}
 
   knip@5.86.0(@types/node@20.19.37)(typescript@5.9.3):
     dependencies:
@@ -11023,6 +12538,8 @@ snapshots:
   language-tags@1.0.9:
     dependencies:
       language-subtag-registry: 0.3.23
+
+  leac@0.6.0: {}
 
   levn@0.4.1:
     dependencies:
@@ -11057,6 +12574,11 @@ snapshots:
 
   lodash@4.17.21: {}
 
+  log-symbols@7.0.1:
+    dependencies:
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.1.2
+
   long@5.3.2: {}
 
   loose-envify@1.4.0:
@@ -11075,9 +12597,13 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  marked@15.0.12: {}
+
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.0.14: {}
+
+  mdn-data@2.27.1: {}
 
   memory-pager@1.5.0: {}
 
@@ -11089,6 +12615,20 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.52.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  mimic-function@5.0.1: {}
 
   minimatch@10.2.4:
     dependencies:
@@ -11181,6 +12721,8 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@0.6.3: {}
+
   next-themes@0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -11205,6 +12747,30 @@ snapshots:
       "@next/swc-linux-x64-musl": 16.1.6
       "@next/swc-win32-arm64-msvc": 16.1.6
       "@next/swc-win32-x64-msvc": 16.1.6
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - "@babel/core"
+      - babel-plugin-macros
+
+  next@16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      "@next/env": 16.2.3
+      "@swc/helpers": 0.5.15
+      baseline-browser-mapping: 2.10.0
+      caniuse-lite: 1.0.30001777
+      postcss: 8.4.31
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
+    optionalDependencies:
+      "@next/swc-darwin-arm64": 16.2.3
+      "@next/swc-darwin-x64": 16.2.3
+      "@next/swc-linux-arm64-gnu": 16.2.3
+      "@next/swc-linux-arm64-musl": 16.2.3
+      "@next/swc-linux-x64-gnu": 16.2.3
+      "@next/swc-linux-x64-musl": 16.2.3
+      "@next/swc-win32-arm64-msvc": 16.2.3
+      "@next/swc-win32-x64-msvc": 16.2.3
       sharp: 0.34.5
     transitivePeerDependencies:
       - "@babel/core"
@@ -11236,11 +12802,11 @@ snapshots:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
 
-  nypm@0.6.5:
+  nypm@0.6.6:
     dependencies:
-      citty: 0.2.1
+      citty: 0.2.2
       pathe: 2.0.3
-      tinyexec: 1.0.2
+      tinyexec: 1.1.2
 
   oauth-1.0a@2.2.6: {}
 
@@ -11358,6 +12924,11 @@ snapshots:
 
   parse-statements@1.0.11: {}
 
+  parseley@0.12.1:
+    dependencies:
+      leac: 0.6.0
+      peberminta: 0.9.0
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -11372,6 +12943,8 @@ snapshots:
       minipass: 7.1.3
 
   pathe@2.0.3: {}
+
+  peberminta@0.9.0: {}
 
   perfect-debounce@1.0.0: {}
 
@@ -11415,6 +12988,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  picospinner@3.0.0: {}
 
   pify@2.3.0: {}
 
@@ -11533,6 +13108,13 @@ snapshots:
       - react
       - react-dom
 
+  prismjs@1.30.0: {}
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -11562,6 +13144,37 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-email@6.0.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      "@babel/parser": 7.27.0
+      "@babel/traverse": 7.27.0
+      "@react-email/render": 2.0.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      chokidar: 4.0.3
+      commander: 13.1.0
+      conf: 15.1.0
+      css-tree: 3.2.1
+      debounce: 2.2.0
+      esbuild: 0.28.0
+      glob: 13.0.6
+      jiti: 2.4.2
+      log-symbols: 7.0.1
+      marked: 15.0.12
+      mime-types: 3.0.2
+      normalize-path: 3.0.0
+      nypm: 0.6.6
+      picospinner: 3.0.0
+      prismjs: 1.30.0
+      prompts: 2.4.2
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      socket.io: 4.8.3
+      tailwindcss: 4.2.4
+      tsconfig-paths: 4.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   react-hook-form@7.71.2(react@19.2.4):
     dependencies:
@@ -11688,6 +13301,8 @@ snapshots:
 
   remeda@2.33.4: {}
 
+  require-from-string@2.0.2: {}
+
   reserved-identifiers@1.2.0: {}
 
   resize-observer-polyfill@1.5.1: {}
@@ -11749,6 +13364,10 @@ snapshots:
   scheduler@0.27.0: {}
 
   screenfull@5.2.0: {}
+
+  selderee@0.11.0:
+    dependencies:
+      parseley: 0.12.1
 
   semver@6.3.1: {}
 
@@ -11885,6 +13504,36 @@ snapshots:
   sisteransi@1.0.5: {}
 
   smol-toml@1.6.0: {}
+
+  socket.io-adapter@2.5.6:
+    dependencies:
+      debug: 4.4.3
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.6:
+    dependencies:
+      "@socket.io/component-emitter": 3.1.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  socket.io@4.8.3:
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io: 6.6.7
+      socket.io-adapter: 2.5.6
+      socket.io-parser: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   sonner@1.7.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -12027,6 +13676,12 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
+  stubborn-fs@2.0.0:
+    dependencies:
+      stubborn-utils: 1.0.2
+
+  stubborn-utils@1.0.2: {}
+
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
@@ -12096,6 +13751,8 @@ snapshots:
       - tsx
       - yaml
 
+  tailwindcss@4.2.4: {}
+
   tapable@2.3.0: {}
 
   thenify-all@1.6.0:
@@ -12108,7 +13765,7 @@ snapshots:
 
   throttle-debounce@3.0.1: {}
 
-  tinyexec@1.0.2: {}
+  tinyexec@1.1.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
@@ -12147,6 +13804,12 @@ snapshots:
     dependencies:
       "@types/json5": 0.0.29
       json5: 1.0.2
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
 
@@ -12217,6 +13880,8 @@ snapshots:
 
   ufo@1.6.3: {}
 
+  uint8array-extras@1.5.0: {}
+
   unbash@2.2.0: {}
 
   unbox-primitive@1.1.0:
@@ -12279,6 +13944,8 @@ snapshots:
 
   validator@13.15.26: {}
 
+  vary@1.1.2: {}
+
   vaul@0.9.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       "@radix-ui/react-dialog": 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -12296,6 +13963,8 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
+
+  when-exit@2.1.5: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -12343,6 +14012,8 @@ snapshots:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
+
+  ws@8.18.3: {}
 
   xtend@4.0.2: {}
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,24 +1,15 @@
-/* eslint-disable no-console */
+import OtpEmail from "@emails/otp-email";
 import { betterAuth } from "better-auth";
 import { usosAuth } from "better-auth-usos";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { nextCookies } from "better-auth/next-js";
 import { emailOTP } from "better-auth/plugins";
-import { createTransport } from "nodemailer";
+import React from "react";
 
 import { db } from "@/db";
 import * as schema from "@/db/schema";
 import { env } from "@/env.mjs";
-
-const mailer = createTransport({
-  host: env.SMTP_HOST,
-  port: env.SMTP_PORT,
-  secure: env.SMTP_PORT === 465,
-  auth:
-    env.SMTP_PASSWORD === ""
-      ? undefined
-      : { user: env.SMTP_USERNAME, pass: env.SMTP_PASSWORD },
-});
+import { sendMail } from "@/lib/mailer";
 
 export const auth = betterAuth({
   database: drizzleAdapter(db, { provider: "pg", schema }),
@@ -52,26 +43,10 @@ export const auth = betterAuth({
   plugins: [
     emailOTP({
       async sendVerificationOTP({ email, otp }) {
-        if (env.SMTP_PASSWORD === "") {
-          console.log("===========================================");
-          console.log(`[EMAIL OTP DEV] Code for ${email}: ${otp}`);
-          console.log("===========================================");
-          return;
-        }
-        await mailer.sendMail({
-          from: `"Solvro Planer" <${env.SMTP_USERNAME}>`,
+        await sendMail({
           to: email,
           subject: "Kod logowania do Planera | KN Solvro",
-          html: `
-            <div style="font-family: sans-serif; max-width: 480px; margin: 0 auto;">
-              <h2 style="color: #1a1a1a;">Twój kod logowania</h2>
-              <p style="color: #555;">Użyj poniższego kodu, aby zalogować się do Planera Solvro:</p>
-              <div style="background: #f4f4f5; border-radius: 8px; padding: 24px; text-align: center; margin: 24px 0;">
-                <span style="font-size: 36px; font-weight: bold; letter-spacing: 8px; color: #1a1a1a;">${otp}</span>
-              </div>
-              <p style="color: #888; font-size: 13px;">Kod jest ważny przez 5 minut. Jeśli nie próbowałeś się zalogować, zignoruj tę wiadomość.</p>
-            </div>
-          `,
+          template: React.createElement(OtpEmail, { otp }),
         });
       },
       otpLength: 6,
@@ -96,7 +71,7 @@ export const auth = betterAuth({
       }),
       // eslint-disable-next-line @typescript-eslint/require-await
       onSuccess: async (user) => {
-        console.log(
+        console.warn(
           `[USOS AUTH] User logged in: ${user.firstName} ${user.lastName} (${user.studentNumber?.toString() ?? "N/A"})`,
         );
         return "/plans";

--- a/src/lib/mailer.ts
+++ b/src/lib/mailer.ts
@@ -1,0 +1,38 @@
+import { createTransport } from "nodemailer";
+import type { ReactElement } from "react";
+import { render } from "react-email";
+
+import { env } from "@/env.mjs";
+
+const transport = createTransport({
+  host: env.SMTP_HOST,
+  port: env.SMTP_PORT,
+  secure: env.SMTP_PORT === 465,
+  auth:
+    env.SMTP_PASSWORD === undefined
+      ? undefined
+      : { user: env.SMTP_USERNAME, pass: env.SMTP_PASSWORD },
+});
+
+interface SendMailOptions {
+  to: string;
+  subject: string;
+  template: ReactElement;
+}
+
+export async function sendMail({ to, subject, template }: SendMailOptions) {
+  if (env.SMTP_PASSWORD === undefined || env.SMTP_PASSWORD === "") {
+    // eslint-disable-next-line no-console
+    console.log(`[MAILER DEV] To: ${to} | Subject: ${subject}`);
+    return;
+  }
+
+  const html = await render(template);
+
+  await transport.sendMail({
+    from: `"Solvro Planer" <${env.SMTP_USERNAME}>`,
+    to,
+    subject,
+    html,
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "jsx": "react-jsx",
     "incremental": true,
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@emails/*": ["./emails/*"]
     },
     "plugins": [
       {


### PR DESCRIPTION
- Introduced OtpEmail component for rendering OTP email content.
- Updated auth.ts to use sendMail function with React email template.
- Removed direct nodemailer usage and SMTP configuration from auth.ts.
- Added mailer.ts for handling email sending logic with nodemailer.
- Updated tsconfig.json to include path for email components.
- Created new otp-email.tsx file for OTP email structure and styling.

<img width="1461" height="791" alt="image" src="https://github.com/user-attachments/assets/63438908-a278-4024-8d9b-bc5f7a22c975" />
