### PR TITLE
feat: add getPlannerCourseGroupsAction (#344)

### DIFF
--- a/src/actions/v2/get-course-edition-details.ts
+++ b/src/actions/v2/get-course-edition-details.ts
@@ -1,0 +1,93 @@
+import redis from "@/lib/redis";
+import { getOrSetRedis } from "@/lib/redis/get-set";
+import { fetchUsosApi } from "@/lib/usos";
+
+interface UsosCourseEdition {
+  course_id: string;
+  term_id: string;
+  course_units_ids: string[] | null;
+}
+
+interface UsosCourseUnitGroup {
+  course_unit_id: string;
+  group_number: number;
+  lecturer_ids: string[] | null;
+}
+
+interface UsosCourseUnit {
+  id: string;
+  classtype_id: string;
+  use_groups: boolean;
+  groups: UsosCourseUnitGroup[] | null;
+}
+
+export interface CourseGroupDTO {
+  unitId: string;
+  groupNumber: string;
+  classtypeId: string;
+  lecturerIds: string[];
+}
+
+export interface CourseEditionDetailsDTO {
+  courseId: string;
+  termId: string;
+  groups: CourseGroupDTO[];
+}
+
+async function fetchCourseUnitGroups(unitId: string): Promise<CourseGroupDTO[]> {
+  const data = await fetchUsosApi<UsosCourseUnit>("courses/course_unit", {
+    unit_id: unitId,
+    fields: "id|classtype_id|use_groups|groups[group_number|lecturer_ids]",
+  });
+
+  if (!data.use_groups || data.groups == null || data.groups.length === 0) {
+    return [
+      {
+        unitId: data.id,
+        groupNumber: "1",
+        classtypeId: data.classtype_id,
+        lecturerIds: [],
+      },
+    ];
+  }
+
+  return data.groups.map((group) => ({
+    unitId: data.id,
+    groupNumber: String(group.group_number),
+    classtypeId: data.classtype_id,
+    lecturerIds: group.lecturer_ids ?? [],
+  }));
+}
+
+export async function getCourseEditionDetailsAction(
+  courseId: string,
+  termId: string,
+): Promise<CourseEditionDetailsDTO> {
+  return getOrSetRedis({
+    redis,
+    key: `usos:course_edition_details:${courseId}:${termId}`,
+    ttlSeconds: 60 * 60 * 24,
+    fetcher: async () => {
+      const edition = await fetchUsosApi<UsosCourseEdition>(
+        "courses/course_edition",
+        {
+          course_id: courseId,
+          term_id: termId,
+          fields: "course_units_ids",
+        },
+      );
+
+      const unitIds = edition.course_units_ids ?? [];
+
+      const groupsPerUnit = await Promise.all(
+        unitIds.map(async (unitId) => fetchCourseUnitGroups(unitId)),
+      );
+
+      return {
+        courseId,
+        termId,
+        groups: groupsPerUnit.flat(),
+      };
+    },
+  });
+}

--- a/src/actions/v2/get-course-edition-details.ts
+++ b/src/actions/v2/get-course-edition-details.ts
@@ -34,7 +34,9 @@ export interface CourseEditionDetailsDTO {
   groups: CourseGroupDTO[];
 }
 
-async function fetchCourseUnitGroups(unitId: string): Promise<CourseGroupDTO[]> {
+async function fetchCourseUnitGroups(
+  unitId: string,
+): Promise<CourseGroupDTO[]> {
   const data = await fetchUsosApi<UsosCourseUnit>("courses/course_unit", {
     unit_id: unitId,
     fields: "id|classtype_id|use_groups|groups[group_number|lecturer_ids]",

--- a/src/actions/v2/get-course-groups-for-planner.ts
+++ b/src/actions/v2/get-course-groups-for-planner.ts
@@ -15,10 +15,12 @@ export interface PlannerGroupDTO {
   schedulePattern: GroupSchedulePattern | null;
 }
 
-function toClassgroupDates(group: {
-  startTime: string | null;
-  endTime: string | null;
-}[]): ClassgroupDate[] {
+function toClassgroupDates(
+  group: {
+    startTime: string | null;
+    endTime: string | null;
+  }[],
+): ClassgroupDate[] {
   return group
     .filter(
       (d): d is { startTime: string; endTime: string } =>
@@ -33,7 +35,10 @@ function toClassgroupDates(group: {
 
 async function fetchGroupWithPattern(
   group: CourseGroupDTO,
-): Promise<{ group: CourseGroupDTO; schedulePattern: GroupSchedulePattern | null }> {
+): Promise<{
+  group: CourseGroupDTO;
+  schedulePattern: GroupSchedulePattern | null;
+}> {
   const dates = await getClassgroupDatesAction(group.unitId, group.groupNumber);
   const classgroupDates = toClassgroupDates(dates);
   return {
@@ -49,7 +54,9 @@ export async function getPlannerCourseGroupsAction(
   const editionDetails = await getCourseEditionDetailsAction(courseId, termId);
 
   const [groupsWithPatterns, lecturersMap] = await Promise.all([
-    Promise.all(editionDetails.groups.map(async (group) => fetchGroupWithPattern(group))),
+    Promise.all(
+      editionDetails.groups.map(async (group) => fetchGroupWithPattern(group)),
+    ),
     (async () => {
       const uniqueLecturerIds = [
         ...new Set(editionDetails.groups.flatMap((g) => g.lecturerIds)),

--- a/src/actions/v2/get-course-groups-for-planner.ts
+++ b/src/actions/v2/get-course-groups-for-planner.ts
@@ -33,9 +33,7 @@ function toClassgroupDates(
     }));
 }
 
-async function fetchGroupWithPattern(
-  group: CourseGroupDTO,
-): Promise<{
+async function fetchGroupWithPattern(group: CourseGroupDTO): Promise<{
   group: CourseGroupDTO;
   schedulePattern: GroupSchedulePattern | null;
 }> {

--- a/src/actions/v2/get-course-groups-for-planner.ts
+++ b/src/actions/v2/get-course-groups-for-planner.ts
@@ -1,0 +1,76 @@
+import type { ClassgroupDate } from "@/types";
+import type { GroupSchedulePattern } from "@/lib/utils/build-group-schedule-pattern";
+import type { CourseGroupDTO } from "./get-course-edition-details";
+import type { LecturerDTO } from "./get-lecturer";
+import { buildGroupSchedulePattern } from "@/lib/utils/build-group-schedule-pattern";
+import { getClassgroupDatesAction } from "./get-class-group-dates";
+import { getCourseEditionDetailsAction } from "./get-course-edition-details";
+import { getLecturerAction } from "./get-lecturer";
+
+export interface PlannerGroupDTO {
+  unitId: string;
+  groupNumber: string;
+  classtypeId: string;
+  lecturers: LecturerDTO[];
+  schedulePattern: GroupSchedulePattern | null;
+}
+
+function toClassgroupDates(group: {
+  startTime: string | null;
+  endTime: string | null;
+}[]): ClassgroupDate[] {
+  return group
+    .filter(
+      (d): d is { startTime: string; endTime: string } =>
+        d.startTime != null && d.endTime != null,
+    )
+    .map((d) => ({
+      date: d.startTime.slice(0, 10),
+      startTime: d.startTime,
+      endTime: d.endTime,
+    }));
+}
+
+async function fetchGroupWithPattern(
+  group: CourseGroupDTO,
+): Promise<{ group: CourseGroupDTO; schedulePattern: GroupSchedulePattern | null }> {
+  const dates = await getClassgroupDatesAction(group.unitId, group.groupNumber);
+  const classgroupDates = toClassgroupDates(dates);
+  return {
+    group,
+    schedulePattern: buildGroupSchedulePattern(classgroupDates),
+  };
+}
+
+export async function getPlannerCourseGroupsAction(
+  courseId: string,
+  termId: string,
+): Promise<PlannerGroupDTO[]> {
+  const editionDetails = await getCourseEditionDetailsAction(courseId, termId);
+
+  const [groupsWithPatterns, lecturersMap] = await Promise.all([
+    Promise.all(editionDetails.groups.map(async (group) => fetchGroupWithPattern(group))),
+    (async () => {
+      const uniqueLecturerIds = [
+        ...new Set(editionDetails.groups.flatMap((g) => g.lecturerIds)),
+      ];
+      const lecturerEntries = await Promise.all(
+        uniqueLecturerIds.map(async (id) => {
+          const lecturer = await getLecturerAction(id);
+          return [id, lecturer] as const;
+        }),
+      );
+      return new Map<string, LecturerDTO>(lecturerEntries);
+    })(),
+  ]);
+
+  return groupsWithPatterns.map(({ group, schedulePattern }) => ({
+    unitId: group.unitId,
+    groupNumber: group.groupNumber,
+    classtypeId: group.classtypeId,
+    lecturers: group.lecturerIds
+      .map((id) => lecturersMap.get(id))
+      .filter((l): l is LecturerDTO => l != null),
+    schedulePattern,
+  }));
+}

--- a/src/actions/v2/get-course-groups-for-planner.ts
+++ b/src/actions/v2/get-course-groups-for-planner.ts
@@ -1,10 +1,11 @@
-import type { ClassgroupDate } from "@/types";
 import type { GroupSchedulePattern } from "@/lib/utils/build-group-schedule-pattern";
-import type { CourseGroupDTO } from "./get-course-edition-details";
-import type { LecturerDTO } from "./get-lecturer";
 import { buildGroupSchedulePattern } from "@/lib/utils/build-group-schedule-pattern";
+import type { ClassgroupDate } from "@/types";
+
 import { getClassgroupDatesAction } from "./get-class-group-dates";
+import type { CourseGroupDTO } from "./get-course-edition-details";
 import { getCourseEditionDetailsAction } from "./get-course-edition-details";
+import type { LecturerDTO } from "./get-lecturer";
 import { getLecturerAction } from "./get-lecturer";
 
 export interface PlannerGroupDTO {


### PR DESCRIPTION
- aggregate course edition details, schedule patterns and lecturers per group
- deduplicate lecturer fetches across groups
- frontend receives planner-ready groups with no domain logic