### PR TITLE
feat(sharing): rebuild plan sharing on the same id as everything else

### DIFF
--- a/drizzle/0003_many_post.sql
+++ b/drizzle/0003_many_post.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "schedule" ALTER COLUMN "courses" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "schedule" ALTER COLUMN "registrations" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "schedule" ALTER COLUMN "groups" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "schedule" ADD COLUMN "is_public" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "schedule" ADD COLUMN "public_snapshot" json;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,486 @@
+{
+  "id": "adeda0a1-4b22-4733-a5d6-3d3662cbe430",
+  "prevId": "41d00b09-22c2-41f2-90a2-8ce299636f8d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usos_id": {
+          "name": "usos_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_notifications": {
+          "name": "allow_notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "onboarding_completed": {
+          "name": "onboarding_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule": {
+      "name": "schedule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "courses": {
+          "name": "courses",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registrations": {
+          "name": "registrations",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "groups": {
+          "name": "groups",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "public_snapshot": {
+          "name": "public_snapshot",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_user_id_user_id_fk": {
+          "name": "schedule_user_id_user_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1787437520371,
       "tag": "0002_nasty_newton_destine",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1788186454760,
+      "tag": "0003_many_post",
+      "breakpoints": true
     }
   ]
 }

--- a/src/actions/plans.ts
+++ b/src/actions/plans.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 "use server";
 
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { headers } from "next/headers";
 
@@ -12,6 +12,7 @@ import type {
   CreatePlanResponseType,
   DeletePlanResponseType,
   PlanResponseType,
+  SharedPlan,
 } from "@/types";
 
 import { schedule } from "../db/schema/schedule";
@@ -131,6 +132,73 @@ export const updatePlan = async ({
       updatedAt: result[0].updatedAt.toISOString(),
     },
   };
+};
+
+export const sharePlan = async ({
+  id,
+  snapshot,
+}: {
+  id: string;
+  snapshot: SharedPlan["plan"];
+}): Promise<{ success: boolean; message: string }> => {
+  const session = await getSession();
+  if (session == null) {
+    return { success: false, message: "Musisz się zalogować." };
+  }
+
+  const result = await db
+    .update(schedule)
+    .set({ isPublic: true, publicSnapshot: snapshot })
+    .where(and(eq(schedule.id, id), eq(schedule.userId, session.user.id)))
+    .returning();
+
+  return result.length > 0
+    ? { success: true, message: "Plan udostępniony pomyślnie" }
+    : { success: false, message: "Nie znaleziono planu" };
+};
+
+export const unsharePlan = async ({
+  id,
+}: {
+  id: string;
+}): Promise<{ success: boolean; message: string }> => {
+  const session = await getSession();
+  if (session == null) {
+    return { success: false, message: "Musisz się zalogować." };
+  }
+
+  const result = await db
+    .update(schedule)
+    .set({ isPublic: false, publicSnapshot: null })
+    .where(and(eq(schedule.id, id), eq(schedule.userId, session.user.id)))
+    .returning();
+
+  return result.length > 0
+    ? { success: true, message: "Udostępnianie wyłączone" }
+    : { success: false, message: "Nie znaleziono planu" };
+};
+
+export const getSharedPlan = async ({
+  id,
+}: {
+  id: string;
+}): Promise<SharedPlan | null> => {
+  const scheduleFromDatabase = await db
+    .select()
+    .from(schedule)
+    .where(eq(schedule.id, id));
+
+  if (scheduleFromDatabase.length === 0) {
+    return null;
+  }
+
+  const userSchedule = scheduleFromDatabase[0];
+
+  if (!userSchedule.isPublic || userSchedule.publicSnapshot === null) {
+    return null;
+  }
+
+  return { id: userSchedule.id, plan: userSchedule.publicSnapshot };
 };
 
 export const deletePlan = async ({

--- a/src/app/plans/_components/share-plan-button.tsx
+++ b/src/app/plans/_components/share-plan-button.tsx
@@ -2,12 +2,11 @@
 
 import React from "react";
 import { toast } from "sonner";
-import { v4 as uuidv4 } from "uuid";
 
+import { sharePlan, unsharePlan } from "@/actions/plans";
 import { Icons } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import { env } from "@/env.mjs";
-import { fetchClient } from "@/lib/fetch";
 import type { PlanState } from "@/types";
 
 export function SharePlanButton({ plan }: { plan: PlanState }) {
@@ -15,6 +14,7 @@ export function SharePlanButton({ plan }: { plan: PlanState }) {
     string | null | undefined
   >(plan.sharedId);
   const [generatingLink, setGeneratingLink] = React.useState<boolean>(false);
+  const [unsharing, setUnsharing] = React.useState<boolean>(false);
 
   const handleCopyLink = async (id: string) => {
     await navigator.clipboard.writeText(
@@ -24,37 +24,54 @@ export function SharePlanButton({ plan }: { plan: PlanState }) {
   };
 
   const handleSharePlan = async () => {
+    if (plan.onlineId === null) {
+      toast.error("Najpierw zapisz plan online, aby móc go udostępnić");
+      return;
+    }
+
     setGeneratingLink(true);
-    const preparedData = {
-      name: plan.name,
-      registrations: plan.registrations,
-      courses: plan.courses,
-      allGroups: plan.allGroups,
-    };
-
-    const randomUUID = uuidv4();
-
     try {
-      const response = await fetchClient({
-        url: "/shared",
-        method: "POST",
-        body: JSON.stringify({
-          plan: JSON.stringify(preparedData),
-          id: randomUUID,
-        }),
+      const response = await sharePlan({
+        id: plan.onlineId,
+        snapshot: {
+          name: plan.name,
+          registrations: plan.registrations,
+          courses: plan.courses,
+          allGroups: plan.allGroups,
+        },
       });
 
-      if (response.ok) {
-        setCurrentSharedPlanId(randomUUID);
-        await handleCopyLink(randomUUID);
-        plan.setPlan({ ...plan, sharedId: randomUUID, synced: false });
+      if (response.success) {
+        setCurrentSharedPlanId(plan.onlineId);
+        await handleCopyLink(plan.onlineId);
+        plan.setPlan({ ...plan, sharedId: plan.onlineId });
       } else {
-        toast.error("Wystąpił błąd podczas generowania linku");
+        toast.error(response.message);
       }
     } catch {
       toast.error("Wystąpił błąd podczas generowania linku");
     } finally {
       setGeneratingLink(false);
+    }
+  };
+
+  const handleUnsharePlan = async () => {
+    if (plan.onlineId === null) {
+      return;
+    }
+
+    setUnsharing(true);
+    try {
+      const response = await unsharePlan({ id: plan.onlineId });
+
+      if (response.success) {
+        setCurrentSharedPlanId(null);
+        plan.setPlan({ ...plan, sharedId: null });
+      } else {
+        toast.error(response.message);
+      }
+    } finally {
+      setUnsharing(false);
     }
   };
 
@@ -68,7 +85,7 @@ export function SharePlanButton({ plan }: { plan: PlanState }) {
           size="sm"
           className="rounded-full"
           variant="secondary"
-          disabled={generatingLink}
+          disabled={generatingLink || plan.onlineId === null}
           onClick={handleSharePlan}
         >
           {generatingLink ? (
@@ -92,15 +109,28 @@ export function SharePlanButton({ plan }: { plan: PlanState }) {
             ) : (
               <Icons.Link className="size-4" />
             )}
-            Nowy link
+            Odśwież
+          </Button>
+          <Button
+            size="sm"
+            className="rounded-none"
+            variant="outline"
+            onClick={async () => handleCopyLink(currentSharedPlanId)}
+          >
+            <Icons.Copy className="size-4" />
           </Button>
           <Button
             size="sm"
             className="rounded-full rounded-l-none"
             variant="outline"
-            onClick={async () => handleCopyLink(currentSharedPlanId)}
+            disabled={unsharing}
+            onClick={handleUnsharePlan}
           >
-            <Icons.Copy className="size-4" />
+            {unsharing ? (
+              <Icons.Loader className="size-4 animate-spin" />
+            ) : (
+              <Icons.X className="size-4" />
+            )}
           </Button>
         </div>
       )}

--- a/src/app/plans/page.tsx
+++ b/src/app/plans/page.tsx
@@ -1,23 +1,6 @@
 import { getUserSchedules } from "@/actions/plans";
-import type { ExtendedCourse } from "@/atoms/plan-family";
-import type { Registration } from "@/types";
 
 import { PlansPage } from "./page.client";
-
-export interface PlanResponseDataType {
-  id: number;
-  userId: number;
-  name: string;
-  sharedId: string | null;
-  createdAt: string;
-  updatedAt: string;
-  courses: ExtendedCourse[];
-  registrations: Registration[];
-}
-
-export interface ErrorResponse {
-  error: string;
-}
 
 export default async function Plans() {
   const userSchedules = await getUserSchedules();

--- a/src/app/plans/preview/[id]/page.tsx
+++ b/src/app/plans/preview/[id]/page.tsx
@@ -2,8 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import React from "react";
 
-import { env } from "@/env.mjs";
-import type { SharedPlan } from "@/types";
+import { getSharedPlan } from "@/actions/plans";
 
 import { SharePlanPage } from "./page.client";
 
@@ -21,25 +20,11 @@ export default async function SharePlan({ params }: PageProps) {
     return notFound();
   }
 
-  const result = await fetch(`${env.SITE_URL}/api/v2/shared/${id}`, {
-    method: "GET",
-  })
-    .then(
-      async (response) =>
-        response.json() as Promise<{
-          success: boolean;
-          plan: SharedPlan;
-        } | null>,
-    )
-    .catch(() => null);
+  const result = await getSharedPlan({ id });
 
-  if (result?.success === false || result === null) {
+  if (result === null) {
     return notFound();
   }
 
-  const plan = JSON.parse(
-    result.plan.plan as unknown as string,
-  ) as SharedPlan["plan"];
-
-  return <SharePlanPage plan={plan} />;
+  return <SharePlanPage plan={result.plan} />;
 }

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -164,15 +164,17 @@ const DropdownMenuLabel = React.forwardRef<
     inset?: boolean;
   }
 >(({ className, inset, ...props }, ref) => (
-  <DropdownMenuPrimitive.GroupLabel
-    ref={ref}
-    className={cn(
-      "px-2 py-1.5 text-sm font-semibold",
-      (inset ?? false) && "pl-8",
-      className,
-    )}
-    {...props}
-  />
+  <DropdownMenuPrimitive.Group>
+    <DropdownMenuPrimitive.GroupLabel
+      ref={ref}
+      className={cn(
+        "px-2 py-1.5 text-sm font-semibold",
+        (inset ?? false) && "pl-8",
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Group>
 ));
 DropdownMenuLabel.displayName = "DropdownMenuLabel";
 

--- a/src/db/schema/schedule.ts
+++ b/src/db/schema/schedule.ts
@@ -1,5 +1,7 @@
 import { relations } from "drizzle-orm";
-import { json, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { boolean, json, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+
+import type { SharedPlan } from "@/types";
 
 import { user } from "./auth";
 
@@ -16,6 +18,8 @@ export const schedule = pgTable("schedule", {
   userId: text("user_id")
     .notNull()
     .references(() => user.id, { onDelete: "cascade" }),
+  isPublic: boolean("is_public").notNull().default(false),
+  publicSnapshot: json("public_snapshot").$type<SharedPlan["plan"] | null>(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at")
     .defaultNow()

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -96,7 +96,6 @@ export interface CreatePlanResponseType {
 
 export interface PlanResponseType {
   name: string;
-  //sharedId: string | null;
   userId: string;
   id: string;
   createdAt: string;


### PR DESCRIPTION
## Summary
- Sharing (`SharePlanButton` → `POST /shared`, preview page → `GET ${SITE_URL}/api/v2/shared/[id]`) was calling dead legacy-backend endpoints left over from the migration to the drizzle-backed `schedule` table.
- Sharing now piggybacks on the plan's own `onlineId` (the same id used for create/sync everywhere else) instead of a separate random UUID: `schedule` gained `isPublic` / `publicSnapshot` columns, plus `sharePlan` / `unsharePlan` / `getSharedPlan` server actions. A plan must be synced online before it can be shared; shared plans are viewable publicly without login, same as before.
- Removed dead types left over from the same migration (`PlanResponseDataType`, `ErrorResponse`, a commented-out `sharedId` field).
- Fixed a crash on the plans list "..." menu: Base UI's `Menu.GroupLabel` requires a `Menu.Group` context, which `DropdownMenuLabel` wasn't providing after the Radix → Base UI migration.
