### PR TITLE
feat: load USOS spots/parity async so course/registration adds are instant

### DIFF
--- a/src/actions/v2/get-course-groups-for-planner.ts
+++ b/src/actions/v2/get-course-groups-for-planner.ts
@@ -8,7 +8,6 @@ import type { ClassgroupDateDTO } from "./get-class-group-dates";
 import { getClassgroupDatesAction } from "./get-class-group-dates";
 import type { CourseGroupDTO } from "./get-course-edition-details";
 import { getCourseEditionDetailsAction } from "./get-course-edition-details";
-import { getGroupSpotsAction } from "./get-group-spots";
 import type { LecturerDTO } from "./get-lecturer";
 
 export interface PlannerGroupDTO {
@@ -17,6 +16,11 @@ export interface PlannerGroupDTO {
   classtypeId: string;
   lecturers: LecturerDTO[];
   schedulePattern: GroupSchedulePattern | null;
+  /**
+   * Placeholder until `getGroupSpotsAction` (scraped, slower) fills these in
+   * client-side. Left at 0 here so this action only waits on the official
+   * USOS API and returns instantly.
+   */
   spotsOccupied: number;
   spotsTotal: number;
 }
@@ -38,15 +42,8 @@ function toClassgroupDates(dates: ClassgroupDateDTO[]): ClassgroupDate[] {
 async function buildPlannerGroup(
   group: CourseGroupDTO,
 ): Promise<PlannerGroupDTO> {
-  const [dates, spots] = await Promise.all([
-    getClassgroupDatesAction(group.unitId, group.groupNumber),
-    getGroupSpotsAction(group.unitId, group.groupNumber),
-  ]);
-
+  const dates = await getClassgroupDatesAction(group.unitId, group.groupNumber);
   const schedulePattern = buildGroupSchedulePattern(toClassgroupDates(dates));
-  if (schedulePattern != null) {
-    schedulePattern.parity = spots.parity;
-  }
 
   return {
     unitId: group.unitId,
@@ -54,8 +51,8 @@ async function buildPlannerGroup(
     classtypeId: group.classtypeId,
     lecturers: group.lecturers,
     schedulePattern,
-    spotsOccupied: spots.spotsOccupied,
-    spotsTotal: spots.spotsTotal,
+    spotsOccupied: 0,
+    spotsTotal: 0,
   };
 }
 

--- a/src/app/plans/edit/[id]/_components/app-sidebar.tsx
+++ b/src/app/plans/edit/[id]/_components/app-sidebar.tsx
@@ -31,8 +31,10 @@ import {
 } from "@/components/ui/sidebar";
 import { Skeleton } from "@/components/ui/skeleton";
 import { exportPlanToIcs } from "@/lib/plan/export-ics";
+import { planUpdates } from "@/lib/plan/plan-updates";
 import {
   RegistrationUnavailableError,
+  refreshGroupSpots,
   useRegistrationCoursesFetcher,
   withSelection,
 } from "@/lib/plan/registration-courses";
@@ -117,12 +119,18 @@ export function AppSidebar({
     setPendingRegistrationId(registrationId);
     try {
       const courses = await fetchCourses(registrationId);
-      plan.addRegistration(
-        registration,
-        withSelection(courses, {
-          isCourseChecked: () => true,
-          isGroupChecked: () => false,
-        }),
+      const selected = withSelection(courses, {
+        isCourseChecked: () => true,
+        isGroupChecked: () => false,
+      });
+      plan.addRegistration(registration, selected);
+      void refreshGroupSpots(
+        selected.flatMap((course) => course.groups),
+        (groupOnlineId, patch) => {
+          plan.setPlan(
+            planUpdates.refreshGroups(new Map([[groupOnlineId, patch]])),
+          );
+        },
       );
     } catch (error) {
       toast.error(

--- a/src/lib/plan/registration-courses.ts
+++ b/src/lib/plan/registration-courses.ts
@@ -5,6 +5,7 @@ import { useCallback } from "react";
 
 import type { PlannerGroupDTO } from "@/actions/v2/get-course-groups-for-planner";
 import { getPlannerCourseGroupsAction } from "@/actions/v2/get-course-groups-for-planner";
+import { getGroupSpotsAction } from "@/actions/v2/get-group-spots";
 import { getRegistrationFacultyAction } from "@/actions/v2/get-registration-faculty";
 import { getRegistrationRoundsAction } from "@/actions/v2/get-registration-rounds";
 import type { RoundCourseDTO } from "@/actions/v2/get-round-courses";
@@ -106,7 +107,43 @@ function toExtendedGroup(
     opinionsCount: 0,
     isChecked: false,
     dates: pattern?.dates ?? [],
+    unitId: group.unitId,
   };
+}
+
+export type GroupSpotsPatch = Pick<
+  ExtendedGroup,
+  "spotsOccupied" | "spotsTotal" | "week"
+>;
+
+const GROUP_SPOTS_CONCURRENCY = 8;
+
+/**
+ * Live spot counts and week parity are scraped from the USOS group page and
+ * are noticeably slower than the official API used to build the groups
+ * themselves, so groups are shown instantly with placeholder spots/parity
+ * and this fills them in afterwards. `onGroupReady` fires per group as its
+ * data arrives instead of waiting for all of them.
+ */
+export async function refreshGroupSpots(
+  groups: ExtendedGroup[],
+  onGroupReady: (groupOnlineId: string, patch: GroupSpotsPatch) => void,
+): Promise<void> {
+  await mapConcurrent(groups, GROUP_SPOTS_CONCURRENCY, async (group) => {
+    if (group.unitId === undefined) {
+      return;
+    }
+    try {
+      const spots = await getGroupSpotsAction(group.unitId, group.groupNumber);
+      onGroupReady(group.groupOnlineId, {
+        spotsOccupied: spots.spotsOccupied,
+        spotsTotal: spots.spotsTotal,
+        week: PARITY_TO_WEEK[spots.parity],
+      });
+    } catch {
+      // Best effort: the group keeps its placeholder spots/parity.
+    }
+  });
 }
 
 async function fetchCourse(

--- a/src/lib/plan/use-plan-sync.ts
+++ b/src/lib/plan/use-plan-sync.ts
@@ -19,6 +19,7 @@ import type {
 import { planUpdates } from "./plan-updates";
 import {
   fetchRegistrationDetails,
+  refreshGroupSpots,
   useRegistrationCoursesFetcher,
   withSelection,
 } from "./registration-courses";
@@ -254,6 +255,12 @@ export function usePlanSync(plan: PlanHandle) {
           updatedAt: online.updatedAt,
         }),
       );
+      void refreshGroupSpots(
+        courses.flatMap((course) => course.groups),
+        (groupOnlineId, patch) => {
+          setPlan(planUpdates.refreshGroups(new Map([[groupOnlineId, patch]])));
+        },
+      );
     } catch {
       toast.error("Nie udało się pobrać kursów", {
         duration: ERROR_TOAST_DURATION_MS,
@@ -292,33 +299,39 @@ export function usePlanSync(plan: PlanHandle) {
     );
 
     const fresh = new Map<string, Partial<ExtendedGroup>>();
+    const groups: ExtendedGroup[] = [];
     for (const result of results) {
       if (result.status !== "fulfilled") {
         continue;
       }
       for (const course of result.value) {
         for (const group of course.groups) {
+          // Spots/parity are scraped and noticeably slower than the rest of
+          // this (official-API) data, so they're refreshed separately below
+          // instead of blocking this patch or momentarily zeroing them out.
           fresh.set(group.groupOnlineId, {
             groupNumber: group.groupNumber,
             courseName: group.courseName,
             courseType: group.courseType,
             lecturer: group.lecturer,
             day: group.day,
-            week: group.week,
             startTime: group.startTime,
             endTime: group.endTime,
-            spotsOccupied: group.spotsOccupied,
-            spotsTotal: group.spotsTotal,
             averageRating: group.averageRating,
             opinionsCount: group.opinionsCount,
             dates: group.dates,
+            unitId: group.unitId,
           });
+          groups.push(group);
         }
       }
     }
     if (fresh.size > 0) {
       setPlan(planUpdates.refreshGroups(fresh));
     }
+    void refreshGroupSpots(groups, (groupOnlineId, patch) => {
+      setPlan(planUpdates.refreshGroups(new Map([[groupOnlineId, patch]])));
+    });
   }, [readPlan, fetchCourses, setPlan]);
 
   const refreshed = useRef(false);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,6 +40,12 @@ export interface ExtendedGroup {
   isChecked: boolean;
   /** Real meeting dates ("YYYY-MM-DD") from USOS; missing on plans saved before this field existed. */
   dates?: string[];
+  /**
+   * USOS course-unit id, used to fetch live spot counts and week parity
+   * after the group is already shown. Missing on plans saved before this
+   * field existed.
+   */
+  unitId?: string;
 }
 
 export interface ExtendedCourse {


### PR DESCRIPTION
## Summary
- Dodawanie kursów/rejestracji do planu było blokowane do czasu zescrapowania liczby miejsc i parzystości dla każdej grupy z każdego kursu w rejestracji — teraz grupy renderują się od razu na podstawie oficjalnego API USOS (terminy zajęć), a scrapowane dane (miejsca, parzystość) doładowywane są w tle per grupa i wpisywane do planu w miarę napływania.
- Dotyczy trzech miejsc: dodawania nowej rejestracji (`app-sidebar.tsx`), pobierania współdzielonego planu (`pull`) i cyklicznego odświeżania danych (`refreshGroups`) w `use-plan-sync.ts`.
- `ExtendedGroup` ma teraz opcjonalne pole `unitId`, żeby dało się doładować miejsca/parzystość bez ponownego przechodzenia całego pipeline'u.

