### PR TITLE
fix: add missing color for class type "D" (diploma classes)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -40,6 +40,7 @@ layer(base);
     --type-c: 142 65% 36%;
     --type-s: 32 87% 43%;
     --type-p: 289 58% 47%;
+    --type-d: 185 65% 33%;
 
     --status-ready: 142 71% 45%;
     --status-collision: 0 72% 55%;
@@ -81,6 +82,7 @@ layer(base);
     --type-c: 142 55% 43%;
     --type-s: 32 83% 47%;
     --type-p: 289 51% 54%;
+    --type-d: 185 60% 50%;
 
     --status-ready: 142 60% 55%;
     --status-collision: 0 75% 65%;

--- a/src/components/schedule/type-colors.ts
+++ b/src/components/schedule/type-colors.ts
@@ -1,31 +1,36 @@
-export const TYPE_LABELS: Record<"W" | "L" | "C" | "S" | "P", string> = {
+export const TYPE_LABELS: Record<"W" | "L" | "C" | "S" | "P" | "D", string> = {
   W: "Wykład",
   L: "Laboratorium",
   C: "Ćwiczenia",
   S: "Seminarium",
   P: "Projekt",
+  D: "Dyplomowe",
 };
 
-export const TYPE_BG: Record<"W" | "L" | "C" | "S" | "P", string> = {
+export const TYPE_BG: Record<"W" | "L" | "C" | "S" | "P" | "D", string> = {
   W: "bg-type-w/45",
   L: "bg-type-l/45",
   C: "bg-type-c/45",
   S: "bg-type-s/45",
   P: "bg-type-p/45",
+  D: "bg-type-d/45",
 };
 
-export const TYPE_BG_MUTED: Record<"W" | "L" | "C" | "S" | "P", string> = {
-  W: "bg-type-w/15",
-  L: "bg-type-l/15",
-  C: "bg-type-c/15",
-  S: "bg-type-s/15",
-  P: "bg-type-p/15",
-};
+export const TYPE_BG_MUTED: Record<"W" | "L" | "C" | "S" | "P" | "D", string> =
+  {
+    W: "bg-type-w/15",
+    L: "bg-type-l/15",
+    C: "bg-type-c/15",
+    S: "bg-type-s/15",
+    P: "bg-type-p/15",
+    D: "bg-type-d/15",
+  };
 
-export const TYPE_BAR: Record<"W" | "L" | "C" | "S" | "P", string> = {
+export const TYPE_BAR: Record<"W" | "L" | "C" | "S" | "P" | "D", string> = {
   W: "bg-type-w",
   L: "bg-type-l",
   C: "bg-type-c",
   S: "bg-type-s",
   P: "bg-type-p",
+  D: "bg-type-d",
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,7 +8,7 @@ export enum Day {
   SUNDAY = "niedziela",
 }
 
-export type ClassType = "C" | "L" | "P" | "S" | "W";
+export type ClassType = "C" | "D" | "L" | "P" | "S" | "W";
 
 /** "" = every week, TN = odd weeks, TP = even weeks, "!" = irregular */
 export type WeekParity = "" | "TN" | "TP" | "!";

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -84,6 +84,7 @@ const config = {
           c: "hsl(var(--type-c))",
           s: "hsl(var(--type-s))",
           p: "hsl(var(--type-p))",
+          d: "hsl(var(--type-d))",
         },
         status: {
           ready: "hsl(var(--status-ready))",


### PR DESCRIPTION
## Summary
- USOS zwraca zajęcia dyplomowe (np. „Praca dyplomowa”, prace magisterskie/inżynierskie) pod typem `D`, którego nie było w `ClassType` ani w mapach kolorów (`TYPE_LABELS`/`TYPE_BG`/`TYPE_BG_MUTED`/`TYPE_BAR`) — te karty renderowały się bez paska/tła koloru.
- Dodano typ `D` do `ClassType`, wpisy w mapach w `type-colors.ts`, zmienną `--type-d` (light/dark) w `globals.css` oraz mapowanie w `tailwind.config.ts`.
