### PR TITLE
fix: allow all paths in robots.txt, add /plans and /login to sitemap

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -5,7 +5,6 @@ export default function robots(): MetadataRoute.Robots {
     rules: {
       userAgent: "*",
       allow: "/",
-      disallow: ["/plans/", "/api/"],
     },
     sitemap: "https://planer.solvro.pl/sitemap.xml",
   };

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,5 +8,17 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 1,
     },
+    {
+      url: "https://planer.solvro.pl/plans",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: "https://planer.solvro.pl/login",
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
   ];
 }


### PR DESCRIPTION
## Summary
- `robots.txt` blokował `/plans/` i `/api/` — usunięto `disallow`, teraz wszystko jest dozwolone dla crawlerów.
- Dodano `/plans` i `/login` do `sitemap.xml` (wcześniej była tylko strona główna).
