### PR TITLE
fix: reject pwr.edu.pl login emails with numeric-only index

### DIFF
--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -7,10 +7,17 @@ export const feedbackFormSchema = z.object({
 });
 
 const emailWithDomainRegex = /^[\w.%+-]+@(student\.)?pwr\.edu\.pl$/;
+const staffEmailWithIndexRegex = /^\d+@pwr\.edu\.pl$/;
 export const loginOtpEmailSchema = z.object({
-  email: z.email({ message: "Niepoprawny email" }).regex(emailWithDomainRegex, {
-    message: "Email musi być z domeny Politechniki Wrocławskiej",
-  }),
+  email: z
+    .email({ message: "Niepoprawny email" })
+    .regex(emailWithDomainRegex, {
+      message: "Email musi być z domeny Politechniki Wrocławskiej",
+    })
+    .refine((email) => !staffEmailWithIndexRegex.test(email), {
+      message:
+        "Studenci logują się mailem z domeny student.pwr.edu.pl, nie pwr.edu.pl",
+    }),
 });
 
 export const otpPinSchema = z.object({

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -15,7 +15,7 @@ export const loginOtpEmailSchema = z.object({
       message: "Email musi być z domeny Politechniki Wrocławskiej",
     })
     .refine((email) => !staffEmailWithIndexRegex.test(email), {
-      message:
+      error:
         "Studenci logują się mailem z domeny student.pwr.edu.pl, nie pwr.edu.pl",
     }),
 });


### PR DESCRIPTION
## Summary
- Logowanie akceptuje maile z domen `student.pwr.edu.pl` i `pwr.edu.pl`.
- Studenci czasem mylą się i wpisują swój numer indeksu pod domeną `pwr.edu.pl` zamiast `student.pwr.edu.pl` (pracownicy mają maile w formacie imię.nazwisko, nigdy same cyfry).
- Dodano dodatkową walidację w `loginOtpEmailSchema`: jeśli local-part maila to same cyfry (`^\d+$`), a domena to `pwr.edu.pl` (bez `student.`), formularz zwraca błąd sugerujący poprawną domenę.

