### PR TITLE
fix: patch @better-auth/cimd's Node lookup callback for Happy Eyeballs

### DIFF
--- a/.github/composite-actions/install/action.yml
+++ b/.github/composite-actions/install/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: 9
+        version: 11.9.0
 
     - name: Set up Node
       uses: actions/setup-node@v4

--- a/patches/@better-auth__cimd@1.7.2.patch
+++ b/patches/@better-auth__cimd@1.7.2.patch
@@ -1,0 +1,16 @@
+diff --git a/dist/node.mjs b/dist/node.mjs
+index a12d50e19d1fa726246f9a2fbe6f76d07471c0ee..6d2f361b8077d0e06799abeaadf6bc3a7c31ec31 100644
+--- a/dist/node.mjs
++++ b/dist/node.mjs
+@@ -46,8 +46,9 @@ const fetchClientMetadataResource = async (input, init) => {
+ 			method: webRequest.method,
+ 			servername: isIP(url.hostname.replace(/^\[|\]$/g, "")) === 0 ? url.hostname : void 0,
+ 			signal,
+-			lookup: (_hostname, _options, callback) => {
+-				callback(null, pinnedAddress.address, pinnedAddress.family);
++			lookup: (_hostname, options, callback) => {
++				if (options?.all) callback(null, [pinnedAddress]);
++				else callback(null, pinnedAddress.address, pinnedAddress.family);
+ 			}
+ 		}, (response) => {
+ 			const status = response.statusCode ?? 500;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  "@better-auth/cimd@1.7.2": af84980519bcf4855ee97b49ae29fe39fe856af00d2f0f844852102e987a3c31
+
 importers:
   .:
     dependencies:
@@ -12,7 +15,7 @@ importers:
         version: 1.7.0(@types/react@19.2.18)(date-fns@4.4.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       "@better-auth/cimd":
         specifier: ^1.7.2
-        version: 1.7.2(8753e6d1b7f4b07d15bf90377001310a)
+        version: 1.7.2(patch_hash=af84980519bcf4855ee97b49ae29fe39fe856af00d2f0f844852102e987a3c31)(8753e6d1b7f4b07d15bf90377001310a)
       "@better-auth/mcp":
         specifier: ^1.7.2
         version: 1.7.2(90bfe96bcd771cdf4a9bc229bbb139de)
@@ -9250,7 +9253,7 @@ snapshots:
     optionalDependencies:
       "@types/react": 19.2.18
 
-  "@better-auth/cimd@1.7.2(8753e6d1b7f4b07d15bf90377001310a)":
+  "@better-auth/cimd@1.7.2(patch_hash=af84980519bcf4855ee97b49ae29fe39fe856af00d2f0f844852102e987a3c31)(8753e6d1b7f4b07d15bf90377001310a)":
     dependencies:
       "@better-auth/core": 1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.4.0(zod@4.5.4))(jose@6.2.10)(kysely@0.29.5)(nanostores@1.5.2)
       "@better-auth/oauth-provider": 1.7.2(90bfe96bcd771cdf4a9bc229bbb139de)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,6 @@ allowBuilds:
 
 minimumReleaseAgeExclude:
   - better-auth-evp@0.1.0 || 1.0.1 || 1.0.2 || 1.0.7
+
+patchedDependencies:
+  "@better-auth/cimd@1.7.2": patches/@better-auth__cimd@1.7.2.patch


### PR DESCRIPTION
## Summary

- `@better-auth/cimd@1.7.2`'s Node fetcher (used by CIMD-based client discovery, e.g. Claude Code's `client_id` metadata document) pins the DNS-resolved address for the connection via a custom `lookup` callback, but always invokes it with the legacy 3-arg `(err, address, family)` form.
- `https.request`'s Happy-Eyeballs connection path (`lookupAndConnectMultiple`) calls that callback with `options.all: true`, which requires the array-style `(err, addresses[])` form instead — the mismatch throws `ERR_INVALID_IP_ADDRESS: Invalid IP address: undefined`, breaking every CIMD metadata fetch.
- Confirmed with an isolated repro script against the real package on both Node 22 and Node 25 — same failure, so it's not Node-version-specific, and not anything in our own code.
- Patches `dist/node.mjs` via `pnpm patch` to branch on `options.all` and respond with the correct callback shape either way.

Verified: `pnpm install --frozen-lockfile` from a clean `node_modules` (matching CI exactly), `pnpm build` with CI's exact env vars, and a direct call to the patched `fetchClientMetadataResource` against `https://claude.ai/oauth/claude-code-client-metadata` returning a proper 200 with the client metadata JSON.