### PR TITLE
fix: pin pnpm via packageManager so every build tool agrees

### DIFF
--- a/.github/composite-actions/install/action.yml
+++ b/.github/composite-actions/install/action.yml
@@ -6,8 +6,6 @@ runs:
   steps:
     - name: Install pnpm
       uses: pnpm/action-setup@v4
-      with:
-        version: 11.9.0
 
     - name: Set up Node
       uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "tsx": "^4.23.13",
     "typescript": "^6.0.3"
   },
+  "packageManager": "pnpm@11.9.0",
   "engines": {
     "node": ">=22.0.0"
   },


### PR DESCRIPTION
## Summary

- Merging #395 fixed GitHub Actions CI but Coolify's deployment (Nixpacks) still failed with the identical `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` — Nixpacks resolves its own pnpm version independently of `.github/composite-actions/install` and picked `pnpm-9_x`, the same stale major that broke CI before.
- Adds `"packageManager": "pnpm@11.9.0"` to `package.json` — the standard corepack signal that Nixpacks, Vercel, Netlify, etc. all read to pick a pnpm version — as the single source of truth, instead of each build system guessing independently.
- Simplifies `.github/composite-actions/install/action.yml` to drop the now-duplicate explicit `version: 11.9.0` and let `pnpm/action-setup` read it from `packageManager` instead (confirmed supported by the action's own docs).

Verified locally: `pnpm install --frozen-lockfile` from a clean `node_modules` and full `pnpm lint`.