### PR TITLE
feat: revamp MCP settings UI with per-client tabs and connection status

### DIFF
--- a/src/app/plans/_components/agent-promo-banner.tsx
+++ b/src/app/plans/_components/agent-promo-banner.tsx
@@ -2,6 +2,7 @@
 
 import { useAtom, useSetAtom } from "jotai";
 import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 import { toast } from "sonner";
 
 import {
@@ -19,6 +20,9 @@ export function AgentPromoBanner() {
   const router = useRouter();
 
   const openMcpSettings = () => {
+    void window.umami?.track("MCP promo banner: check how clicked", {
+      loggedIn: session.data == null ? "false" : "true",
+    });
     if (session.data == null) {
       toast.info("Musisz się zalogować, aby korzystać z MCP");
       router.push("/login");
@@ -26,6 +30,13 @@ export function AgentPromoBanner() {
     }
     setSettings({ open: true, tab: "mcp" });
   };
+
+  useEffect(() => {
+    if (!dismissed) {
+      void window.umami?.track("MCP promo banner: shown");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (dismissed) {
     return null;
@@ -39,6 +50,7 @@ export function AgentPromoBanner() {
         className="absolute top-1 right-1 size-6"
         aria-label="Zamknij"
         onClick={() => {
+          void window.umami?.track("MCP promo banner: dismissed");
           setDismissed(true);
         }}
       >

--- a/src/app/plans/account/_components/mcp-content.tsx
+++ b/src/app/plans/account/_components/mcp-content.tsx
@@ -1,12 +1,22 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 import { Icons } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { authClient } from "@/lib/auth-client";
 
 const mcpUrl = "https://planer.solvro.pl/api/mcp";
+
+interface OAuthConsent {
+  id: string;
+  clientId: string;
+  scopes: string[];
+  createdAt: string;
+}
 
 async function copySnippet(snippet: string) {
   await navigator.clipboard.writeText(snippet);
@@ -34,6 +44,113 @@ function CodeSnippet({ snippet }: { snippet: string }) {
   );
 }
 
+function ConnectedApps() {
+  const [consents, setConsents] = useState<OAuthConsent[] | null>(null);
+  const [names, setNames] = useState<Record<string, string>>({});
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+
+  const loadNames = (items: OAuthConsent[]) => {
+    for (const consent of items) {
+      void authClient.oauth2
+        .getClient({ query: { client_id: consent.clientId } })
+        .then((result: { data: unknown }) => {
+          const client = result.data as { client_name?: string } | null;
+          setNames((previous) => ({
+            ...previous,
+            [consent.clientId]: client?.client_name ?? consent.clientId,
+          }));
+        })
+        .catch(() => {
+          setNames((previous) => ({
+            ...previous,
+            [consent.clientId]: consent.clientId,
+          }));
+        });
+    }
+  };
+
+  const load = () => {
+    void authClient.oauth2
+      .getConsents()
+      .then((result: { data: unknown }) => {
+        const items = (result.data as OAuthConsent[] | null) ?? [];
+        setConsents(items);
+        loadNames(items);
+      })
+      .catch(() => {
+        setConsents([]);
+      });
+  };
+
+  useEffect(load, []);
+
+  const revoke = async (consent: OAuthConsent) => {
+    setRevokingId(consent.id);
+    const { error } = await authClient.oauth2.deleteConsent({
+      id: consent.id,
+    });
+    setRevokingId(null);
+    if (error == null) {
+      toast.success("Rozłączono aplikację");
+      setConsents(
+        (previous) => previous?.filter((c) => c.id !== consent.id) ?? null,
+      );
+    } else {
+      toast.error("Nie udało się rozłączyć aplikacji");
+    }
+  };
+
+  if (consents == null) {
+    return (
+      <p className="text-muted-foreground flex items-center gap-2 text-sm">
+        <Icons.Loader className="size-4 animate-spin" />
+        Sprawdzanie połączonych aplikacji…
+      </p>
+    );
+  }
+
+  if (consents.length === 0) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        Żadna aplikacja nie ma jeszcze dostępu do Twojego konta przez MCP.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-2">
+      {consents.map((consent) => (
+        <li
+          key={consent.id}
+          className="flex items-center justify-between gap-3 rounded-md border p-3"
+        >
+          <div className="flex items-center gap-2 text-sm">
+            <Icons.Check className="size-4 shrink-0 text-green-600" />
+            <span className="font-medium">
+              {names[consent.clientId] ?? consent.clientId}
+            </span>
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={revokingId === consent.id}
+            onClick={() => {
+              void revoke(consent);
+            }}
+          >
+            {revokingId === consent.id ? (
+              <Icons.Loader className="size-3.5 animate-spin" />
+            ) : (
+              <Icons.Trash className="size-3.5" />
+            )}
+            Rozłącz
+          </Button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
 export function McpContent() {
   return (
     <div className="mb-8 w-full space-y-6">
@@ -45,58 +162,94 @@ export function McpContent() {
           naturalnym języku.
         </p>
       </div>
-      <Separator />
-      <div className="space-y-3">
-        <Title title="Aplikacja Claude (web, desktop, mobile)" step={1} />
-        <p>
-          Ustawienia → Konektory → Dodaj niestandardowy konektor i wklej
-          poniższy adres. Claude poprosi o zalogowanie się do Planera i
-          potwierdzenie dostępu.
-        </p>
-        <CodeSnippet snippet={mcpUrl} />
-      </div>
-      <div className="space-y-3">
-        <Title title="Claude Code" step={2} />
-        <p>Dodaj serwer poleceniem w terminalu:</p>
-        <CodeSnippet
-          snippet={`claude mcp add --transport http planer ${mcpUrl}`}
-        />
-      </div>
-      <div className="space-y-3">
-        <Title title="opencode" step={3} />
-        <p>
-          Dodaj wpis do <code>opencode.json</code>:
-        </p>
-        <CodeSnippet
-          snippet={JSON.stringify(
-            {
-              mcp: {
-                planer: {
-                  type: "remote",
-                  url: mcpUrl,
-                  enabled: true,
-                },
-              },
-            },
-            null,
-            2,
-          )}
-        />
-        <p>
-          Następnie autoryzuj połączenie: <code>opencode mcp auth planer</code>
-        </p>
-      </div>
-    </div>
-  );
-}
 
-function Title({ title, step }: { title: string; step: number }) {
-  return (
-    <div className="flex items-center gap-3">
-      <div className="bg-primary flex size-10 items-center justify-center rounded-md text-lg font-semibold text-white">
-        {step}.
+      <Separator />
+
+      <div className="space-y-3">
+        <h4 className="text-sm font-semibold">Połączone aplikacje</h4>
+        <ConnectedApps />
       </div>
-      <h1 className="text-lg font-semibold">{title}</h1>
+
+      <Separator />
+
+      <div className="space-y-3">
+        <h4 className="text-sm font-semibold">Jak połączyć</h4>
+        <Tabs defaultValue="claude">
+          <TabsList>
+            <TabsTrigger value="claude">Claude</TabsTrigger>
+            <TabsTrigger value="claude-code">Claude Code</TabsTrigger>
+            <TabsTrigger value="opencode">opencode</TabsTrigger>
+            <TabsTrigger value="codex">Codex</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="claude" className="space-y-3">
+            <p className="text-muted-foreground text-sm">
+              Dotyczy aplikacji Claude na wersji webowej, desktopowej i
+              mobilnej.
+            </p>
+            <p className="text-sm">
+              Ustawienia → Konektory → Dodaj niestandardowy konektor i wklej
+              poniższy adres. Claude poprosi o zalogowanie się do Planera i
+              potwierdzenie dostępu.
+            </p>
+            <CodeSnippet snippet={mcpUrl} />
+          </TabsContent>
+
+          <TabsContent value="claude-code" className="space-y-3">
+            <p className="text-sm">Dodaj serwer poleceniem w terminalu:</p>
+            <CodeSnippet
+              snippet={`claude mcp add --transport http planer ${mcpUrl}`}
+            />
+            <p className="text-muted-foreground text-sm">
+              Przy pierwszym użyciu narzędzia Claude Code poprosi o zalogowanie
+              się i potwierdzenie dostępu w przeglądarce.
+            </p>
+          </TabsContent>
+
+          <TabsContent value="opencode" className="space-y-3">
+            <p className="text-sm">
+              Najprościej przez kreator w terminalu — odpowiedz na pytania
+              (nazwa serwera, typ <code>remote</code>, adres URL):
+            </p>
+            <CodeSnippet snippet="opencode mcp add" />
+            <p className="text-muted-foreground text-sm">
+              Podaj powyższy adres jako URL serwera:
+            </p>
+            <CodeSnippet snippet={mcpUrl} />
+            <p className="text-sm">Następnie autoryzuj połączenie:</p>
+            <CodeSnippet snippet="opencode mcp auth planer" />
+            <p className="text-muted-foreground text-sm">
+              Możesz też dodać wpis ręcznie do <code>opencode.json</code>:
+            </p>
+            <CodeSnippet
+              snippet={JSON.stringify(
+                {
+                  mcp: {
+                    planer: {
+                      type: "remote",
+                      url: mcpUrl,
+                      enabled: true,
+                    },
+                  },
+                },
+                null,
+                2,
+              )}
+            />
+          </TabsContent>
+
+          <TabsContent value="codex" className="space-y-3">
+            <p className="text-sm">
+              Dodaj wpis do <code>~/.codex/config.toml</code>:
+            </p>
+            <CodeSnippet snippet={`[mcp_servers.planer]\nurl = "${mcpUrl}"`} />
+            <p className="text-muted-foreground text-sm">
+              Przy pierwszym użyciu Codex CLI otworzy przeglądarkę, w której
+              zalogujesz się do Planera i potwierdzisz dostęp.
+            </p>
+          </TabsContent>
+        </Tabs>
+      </div>
     </div>
   );
 }

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "bg-muted text-muted-foreground inline-flex h-9 items-center justify-start gap-1 rounded-lg p-1",
+      className,
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = "TabsList";
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Tab>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Tab>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Tab
+    ref={ref}
+    className={cn(
+      "ring-offset-background focus-visible:ring-ring data-active:bg-background data-active:text-foreground inline-flex items-center justify-center gap-1.5 rounded-md px-3 py-1 text-sm font-medium whitespace-nowrap transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-active:shadow-sm",
+      className,
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = "TabsTrigger";
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Panel>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Panel>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Panel
+    ref={ref}
+    className={cn(
+      "ring-offset-background focus-visible:ring-ring mt-4 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none",
+      className,
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = "TabsContent";
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };


### PR DESCRIPTION
## Summary
- MCP settings panel now shows connected apps (via `authClient.oauth2.getConsents()`) with the ability to disconnect (`deleteConsent`).
- Setup instructions split into tabs per client: Claude, Claude Code, opencode (including the `opencode mcp add` wizard), Codex — replacing the old numbered 1/2/3 steps.
- Added Umami events on the MCP promo banner (`shown`, `dismissed`, `check how clicked`) to compare the funnel against the existing `MCP consent accepted/rejected` tracking on the consent screen.
- New shared `src/components/ui/tabs.tsx` component (Base UI Tabs wrapper).