### PR TITLE
feat: better collision detection/pill, last-used login highlight

### DIFF
--- a/src/app/(homepage)/login/login-client.tsx
+++ b/src/app/(homepage)/login/login-client.tsx
@@ -14,6 +14,7 @@ import SolvroLogoMono from "@/../public/assets/logo/logo_solvro_mono.png";
 import BgImage from "@/../public/assets/planer-bg.png";
 import { handleTriggerConfetti } from "@/components/confetti";
 import { Icons } from "@/components/icons";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Field,
@@ -30,6 +31,7 @@ import {
   InputOTPSlot,
 } from "@/components/ui/input-otp";
 import { authClient } from "@/lib/auth-client";
+import { cn } from "@/lib/utils";
 import {
   loginOtpEmailSchema,
   otpPinSchema,
@@ -108,6 +110,7 @@ function EmailStep({
 }) {
   const router = useRouter();
   const [isPasskeyLoading, setIsPasskeyLoading] = useState(false);
+  const lastMethod = authClient.getLastUsedLoginMethod();
   const form = useForm<z.infer<typeof loginOtpEmailSchema>>({
     resolver: zodResolver(loginOtpEmailSchema),
     defaultValues: { email: "" },
@@ -221,14 +224,23 @@ function EmailStep({
 
   return (
     <div className="mt-5 flex w-full max-w-xs flex-col gap-4 text-center">
-      <Button
-        variant="outline"
-        className="w-full"
-        onClick={handleUsosLogin}
-        type="button"
-      >
-        Zaloguj się przez USOS
-      </Button>
+      <div className="relative">
+        <Button
+          variant="outline"
+          className={cn("w-full", {
+            "ring-primary ring-2 ring-offset-2": lastMethod === "usos-auth",
+          })}
+          onClick={handleUsosLogin}
+          type="button"
+        >
+          Zaloguj się przez USOS
+        </Button>
+        {lastMethod === "usos-auth" && (
+          <Badge className="absolute -top-3.5 -right-4 text-[10px]">
+            Ostatnio użyta
+          </Badge>
+        )}
+      </div>
       <div className="after:border-border relative text-center text-sm after:absolute after:inset-0 after:top-1/2 after:z-0 after:flex after:items-center after:border-t">
         <span className="bg-background text-muted-foreground relative z-10 px-2">
           Lub kontynuuj poprzez
@@ -267,27 +279,55 @@ function EmailStep({
           nonce={evpNonce}
           autoComplete="email-verification-token"
         />
-        <Button type="submit" size="sm" className="w-full" disabled={isLoading}>
-          {isLoading ? <Icons.Loader className="size-4 animate-spin" /> : null}
-          Wyślij kod
-        </Button>
-        <Button
-          type="button"
-          variant="secondary"
-          size="sm"
-          className="w-full"
-          disabled={isPasskeyLoading}
-          onClick={() => {
-            void handlePasskeyLogin();
-          }}
-        >
-          {isPasskeyLoading ? (
-            <Icons.Loader className="size-4 animate-spin" />
-          ) : (
-            <Icons.Fingerprint className="size-4" />
+        <div className="relative">
+          <Button
+            type="submit"
+            size="sm"
+            className={cn("w-full", {
+              "ring-secondary ring-2 ring-offset-2": lastMethod === "email-otp",
+            })}
+            disabled={isLoading}
+          >
+            {isLoading ? (
+              <Icons.Loader className="size-4 animate-spin" />
+            ) : null}
+            Wyślij kod
+          </Button>
+          {lastMethod === "email-otp" && (
+            <Badge
+              variant="secondary"
+              className="absolute -top-3.5 -right-4 text-[10px]"
+            >
+              Ostatnio użyta
+            </Badge>
           )}
-          Zaloguj się kluczem dostępu
-        </Button>
+        </div>
+        <div className="relative">
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className={cn("w-full", {
+              "ring-primary ring-2 ring-offset-2": lastMethod === "passkey",
+            })}
+            disabled={isPasskeyLoading}
+            onClick={() => {
+              void handlePasskeyLogin();
+            }}
+          >
+            {isPasskeyLoading ? (
+              <Icons.Loader className="size-4 animate-spin" />
+            ) : (
+              <Icons.Fingerprint className="size-4" />
+            )}
+            Zaloguj się kluczem dostępu
+          </Button>
+          {lastMethod === "passkey" && (
+            <Badge className="absolute -top-3.5 -right-4 text-[10px]">
+              Ostatnio użyta
+            </Badge>
+          )}
+        </div>
       </form>
     </div>
   );

--- a/src/components/schedule/collision-banner.tsx
+++ b/src/components/schedule/collision-banner.tsx
@@ -1,29 +1,70 @@
 import { AlertTriangle } from "lucide-react";
 
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { ALL_DAYS } from "@/constants/days";
 import { pluralize } from "@/lib/utils";
 import type { Collision } from "@/lib/utils/detect-collisions";
 
 import { formatMinutes } from "./time-scale";
 
+function dayLabel(day: Collision["day"]) {
+  return ALL_DAYS.find((d) => d.day === day)?.label ?? day;
+}
+
 export function CollisionBanner({ collisions }: { collisions: Collision[] }) {
   if (collisions.length === 0) {
     return null;
   }
 
-  const first = collisions[0];
-  const dayLabel =
-    ALL_DAYS.find((d) => d.day === first.day)?.label ?? first.day;
+  const dayOrder = new Map(ALL_DAYS.map((d, index) => [d.day, index]));
+  const sorted = [...collisions].toSorted(
+    (a, b) =>
+      (dayOrder.get(a.day) ?? 0) - (dayOrder.get(b.day) ?? 0) ||
+      a.startMinutes - b.startMinutes,
+  );
 
   return (
-    <div className="border-status-collision/40 bg-status-collision/10 text-status-collision flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium">
-      <AlertTriangle className="size-4 shrink-0" />
-      <span>
-        {collisions.length}{" "}
-        {pluralize(collisions.length, "kolizja", "kolizje", "kolizji")} —{" "}
-        {dayLabel.slice(0, 2).toLowerCase()}.{" "}
-        {formatMinutes(first.startMinutes)}
-      </span>
-    </div>
+    <Popover>
+      <PopoverTrigger className="border-status-collision/40 bg-status-collision/10 text-status-collision flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm font-medium">
+        <AlertTriangle className="size-4 shrink-0" />
+        <span>
+          {collisions.length}{" "}
+          {pluralize(collisions.length, "kolizja", "kolizje", "kolizji")}
+        </span>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80">
+        <div className="flex flex-col gap-2">
+          <p className="text-sm font-semibold">
+            {collisions.length}{" "}
+            {pluralize(collisions.length, "kolizja", "kolizje", "kolizji")}
+          </p>
+          <ul className="flex flex-col gap-2 text-sm">
+            {sorted.map((collision) => {
+              const [a, b] = collision.groups;
+              return (
+                <li
+                  key={`${collision.day}-${collision.startMinutes.toString()}-${a.groupId}-${b.groupId}`}
+                  className="border-border/60 flex flex-col gap-0.5 border-b pb-2 last:border-0 last:pb-0"
+                >
+                  <span className="text-foreground font-medium">
+                    {dayLabel(collision.day)},{" "}
+                    {formatMinutes(collision.startMinutes)}–
+                    {formatMinutes(collision.endMinutes)}
+                  </span>
+                  <span className="text-muted-foreground">
+                    {a.courseName} ({a.courseType}) vs {b.courseName} (
+                    {b.courseType})
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -76,7 +76,7 @@ export function SettingsDialog({
                   onTabChange(item.id);
                 }}
                 className={cn(
-                  "flex w-full shrink-0 items-start gap-2 rounded-md px-3 py-2 text-left text-sm font-medium whitespace-nowrap transition-colors sm:whitespace-normal",
+                  "flex w-auto shrink-0 items-start gap-2 rounded-md px-3 py-2 text-left text-sm font-medium whitespace-nowrap transition-colors sm:whitespace-normal md:w-full",
                   tab === item.id
                     ? "bg-muted text-foreground"
                     : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -5,6 +5,7 @@ import { usosAuthClient } from "better-auth-usos/client";
 import {
   emailOTPClient,
   inferAdditionalFields,
+  lastLoginMethodClient,
 } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
@@ -21,6 +22,7 @@ export const authClient = createAuthClient({
     usosAuthClient(),
     passkeyClient(),
     oauthProviderClient(),
+    lastLoginMethodClient(),
   ],
 });
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -8,7 +8,7 @@ import { emailVerificationProtocol } from "better-auth-evp";
 import { usosAuth } from "better-auth-usos";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { nextCookies } from "better-auth/next-js";
-import { emailOTP, jwt } from "better-auth/plugins";
+import { emailOTP, jwt, lastLoginMethod } from "better-auth/plugins";
 import React from "react";
 
 import { db } from "@/db";
@@ -96,6 +96,17 @@ export const auth = betterAuth({
       origin: env.SITE_URL,
     }),
     jwt(),
+    lastLoginMethod({
+      customResolveMethod: (context) => {
+        if (context.path === "/sign-in/email-otp") {
+          return "email-otp";
+        }
+        if (context.path === "/usos/callback") {
+          return "usos-auth";
+        }
+        return null;
+      },
+    }),
     mcp({
       loginPage: "/login",
       consentPage: "/consent",

--- a/src/lib/utils/detect-collisions.ts
+++ b/src/lib/utils/detect-collisions.ts
@@ -24,6 +24,24 @@ function weeksOverlap(a: ExtendedGroup["week"], b: ExtendedGroup["week"]) {
   return a === b;
 }
 
+/**
+ * `week` (TN/TP) comes from scraping the group page and can stay "" (unknown)
+ * even for a genuinely biweekly group. Actual meeting dates come straight
+ * from the official schedule API, so when both groups have them, trust
+ * those instead: no shared date means no real collision even if `week`
+ * hasn't resolved yet.
+ */
+function datesOverlap(
+  a: string[] | undefined,
+  b: string[] | undefined,
+): boolean | undefined {
+  if (a === undefined || b === undefined || a.length === 0 || b.length === 0) {
+    return undefined;
+  }
+  const bDates = new Set(b);
+  return a.some((date) => bDates.has(date));
+}
+
 export function detectCollisions(groups: ExtendedGroup[]): Collision[] {
   const byDay = new Map<Day, ExtendedGroup[]>();
   for (const group of groups) {
@@ -51,7 +69,9 @@ export function detectCollisions(groups: ExtendedGroup[]): Collision[] {
         if (!rangesOverlap(aStart, aEnd, bStart, bEnd)) {
           continue;
         }
-        if (!weeksOverlap(a.week, b.week)) {
+        const sharedDate = datesOverlap(a.dates, b.dates);
+        const overlaps = sharedDate ?? weeksOverlap(a.week, b.week);
+        if (!overlaps) {
           continue;
         }
 


### PR DESCRIPTION
## Summary
- Collision detection now trusts actual meeting dates over the scraped week-parity field when both are available, so alternating odd/even (TN/TP) classes at the same hour are no longer flagged as colliding when parity hasn't been scraped yet.
- The collision pill is now a popover listing every collision with its day, time range, and the two classes involved, instead of showing only the first collision's hour.
- Login screen highlights whichever method (USOS, passkey, email OTP) the user used last time, backed by better-auth's `lastLoginMethod` plugin.
- Fixed settings tab buttons stretching awkwardly on small screens.