### PR TITLE
fix: heading hierarchy, add JSON-LD, and make the sitemap static

### DIFF
--- a/src/app/(homepage)/_components/github-section/github-item.tsx
+++ b/src/app/(homepage)/_components/github-section/github-item.tsx
@@ -33,12 +33,12 @@ export function GithubItem({
     >
       <div className="relative container mx-auto max-w-7xl px-4 py-16">
         <div className="mx-auto space-y-4 pb-6 text-center">
-          <motion.h2
+          <motion.p
             variants={childVariants}
             className="text-primary font-mono text-sm font-medium tracking-wider uppercase"
           >
             autorzy
-          </motion.h2>
+          </motion.p>
           <AnimatedTitle>
             <TitleHighlight>{contributorsCount} developerów</TitleHighlight>
             <TitleText> tworzy ten projekt</TitleText>

--- a/src/app/(homepage)/_components/problem-section.tsx
+++ b/src/app/(homepage)/_components/problem-section.tsx
@@ -39,12 +39,12 @@ export function ProblemSection() {
     >
       <div className="relative container mx-auto max-w-7xl px-4 py-16">
         <div className="mx-auto space-y-4 pb-6 text-center">
-          <motion.h2
+          <motion.p
             variants={childVariants}
             className="text-primary font-mono text-sm font-medium tracking-wider uppercase"
           >
             problem
-          </motion.h2>
+          </motion.p>
           <AnimatedTitle>
             <TitleText>Układanie planu zajęć to </TitleText>
             <TitleHighlight>nie lada wyzwanie</TitleHighlight>

--- a/src/app/(homepage)/_components/solution-section.tsx
+++ b/src/app/(homepage)/_components/solution-section.tsx
@@ -80,12 +80,12 @@ export function SolutionSection() {
           transition={{ staggerChildren: 0.1 }}
         >
           <div className="mx-auto space-y-4 pb-6 text-center">
-            <motion.h2
+            <motion.p
               variants={childVariants}
               className="text-primary font-mono text-sm font-medium tracking-wider uppercase"
             >
               rozwiązanie
-            </motion.h2>
+            </motion.p>
             <AnimatedTitle>
               <TitleText>Ułóż swój </TitleText>
               <TitleHighlight>wymarzony plan</TitleHighlight>

--- a/src/app/(homepage)/_components/topwr-section.tsx
+++ b/src/app/(homepage)/_components/topwr-section.tsx
@@ -23,13 +23,13 @@ export function ToPWrSection() {
           transition={{ staggerChildren: 0.1 }}
         >
           <div className="mx-auto space-y-4 pb-6 text-center">
-            <motion.h2
+            <motion.p
               variants={childVariants}
               className="font-mono text-sm font-semibold tracking-wider text-orange-500 uppercase"
             >
               Jesteś studentem politechniki wrocławskiej?
-            </motion.h2>
-            <motion.h3
+            </motion.p>
+            <motion.h2
               variants={childVariants}
               className="mx-auto mt-4 max-w-xs text-3xl font-bold tracking-tight sm:max-w-none sm:text-4xl md:text-5xl"
             >
@@ -41,7 +41,7 @@ export function ToPWrSection() {
                 width={140}
                 height={50}
               />
-            </motion.h3>
+            </motion.h2>
             <motion.p
               variants={childVariants}
               className="text-muted-foreground mx-auto mt-6 max-w-2xl text-lg leading-6 text-balance"

--- a/src/app/(homepage)/page.tsx
+++ b/src/app/(homepage)/page.tsx
@@ -7,6 +7,7 @@ import { AuroraBackground } from "@/components/homepage/aurora-background";
 import { ParticleLogo } from "@/components/homepage/particle-logo";
 import { Icons } from "@/components/icons";
 import { BorderBeam } from "@/components/magicui/border-beam";
+import { StructuredData } from "@/components/structured-data";
 import { Button } from "@/components/ui/button";
 import { getCachedAlerts } from "@/lib/get-cached-alerts";
 import { getCachedSession } from "@/lib/get-session";
@@ -74,6 +75,7 @@ export default async function Home() {
 
   return (
     <main className="mx-auto flex-1 overflow-hidden">
+      <StructuredData />
       <section
         id="hero"
         className="relative mx-auto max-w-[80rem] px-2 text-center md:px-8"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { ClientProviders } from "@/components/providers";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
 import { env } from "@/env.mjs";
+import { SITE_DESCRIPTION, SITE_ORIGIN, SITE_TITLE } from "@/lib/site";
 import { cn } from "@/lib/utils";
 import type { UmamiTracker } from "@/types/umami";
 
@@ -16,7 +17,7 @@ import "./globals.css";
 export const metadata: Metadata = {
   title: {
     template: "%s | Planer Solvro",
-    default: "Planer - utwórz swój plan zajęć na PWR!",
+    default: SITE_TITLE,
   },
   icons: [
     {
@@ -34,8 +35,7 @@ export const metadata: Metadata = {
       url: "/favicon-16x16.png",
     },
   ],
-  description:
-    "Planer to strona stworzona z myślą o studentach PWR, którzy pragną w prosty i intuicyjny sposób zarządzać swoimi zapisami na kursy (za darmo!).",
+  description: SITE_DESCRIPTION,
   robots: "index, follow",
   keywords: [
     "planer",
@@ -54,16 +54,15 @@ export const metadata: Metadata = {
     canonical: "./",
   },
   openGraph: {
-    title: "Planer - utwórz swój plan zajęć na PWR!",
-    description:
-      "Planer to strona stworzona z myślą o studentach PWR, którzy pragną w prosty i intuicyjny sposób zarządzać swoimi zapisami na kursy (za darmo!).",
-    url: `https://planer.solvro.pl/`,
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    url: SITE_ORIGIN,
     images: [
       {
         url: "/og_image.png",
         width: 2170,
         height: 1064,
-        alt: "Planer - utwórz swój plan zajęć na PWR!",
+        alt: SITE_TITLE,
       },
     ],
     locale: "pl_PL",
@@ -71,13 +70,13 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Planer - utwórz swój plan zajęć na PWR!",
-    description: "https://planer.solvro.pl/",
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
     images: ["/og_image.png"],
   },
   appleWebApp: {
     statusBarStyle: "black",
-    title: "Planer - utwórz swój plan zajęć na PWR!",
+    title: SITE_TITLE,
     startupImage: "/apple_startup_image.png",
   },
   manifest: "/site.webmanifest",

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,11 +1,13 @@
 import type { MetadataRoute } from "next";
 
+import { SITE_ORIGIN } from "@/lib/site";
+
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: "*",
       allow: "/",
     },
-    sitemap: "https://planer.solvro.pl/sitemap.xml",
+    sitemap: `${SITE_ORIGIN}/sitemap.xml`,
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,22 +1,26 @@
 import type { MetadataRoute } from "next";
 
+import { SITE_ORIGIN } from "@/lib/site";
+
+const LAST_CONTENT_CHANGE = new Date("2026-09-05");
+
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: "https://planer.solvro.pl/",
-      lastModified: new Date(),
+      url: SITE_ORIGIN,
+      lastModified: LAST_CONTENT_CHANGE,
       changeFrequency: "monthly",
       priority: 1,
     },
     {
-      url: "https://planer.solvro.pl/plans",
-      lastModified: new Date(),
+      url: `${SITE_ORIGIN}/plans`,
+      lastModified: LAST_CONTENT_CHANGE,
       changeFrequency: "monthly",
       priority: 0.8,
     },
     {
-      url: "https://planer.solvro.pl/login",
-      lastModified: new Date(),
+      url: `${SITE_ORIGIN}/login`,
+      lastModified: LAST_CONTENT_CHANGE,
       changeFrequency: "monthly",
       priority: 0.5,
     },

--- a/src/components/animated-title.tsx
+++ b/src/components/animated-title.tsx
@@ -7,13 +7,13 @@ import { childVariants } from "@/constants";
 
 export function AnimatedTitle({ children }: { children: React.ReactNode }) {
   return (
-    <motion.h1
+    <motion.h2
       whileHover={{ scale: 1.05 }}
       variants={childVariants}
       className="group relative z-10 mx-auto mt-4 max-w-xs transform-gpu text-3xl font-semibold transition-all sm:max-w-none sm:text-4xl md:text-5xl"
     >
       {children}
-    </motion.h1>
+    </motion.h2>
   );
 }
 

--- a/src/components/structured-data.tsx
+++ b/src/components/structured-data.tsx
@@ -1,0 +1,109 @@
+import { SITE_DESCRIPTION, SITE_ORIGIN, SITE_TITLE } from "@/lib/site";
+
+const ORGANIZATION_ID = `${SITE_ORIGIN}/#organization`;
+const APPLICATION_ID = `${SITE_ORIGIN}/#webapp`;
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": ORGANIZATION_ID,
+      name: "Koło Naukowe Solvro",
+      url: "https://solvro.pwr.edu.pl/",
+      logo: `${SITE_ORIGIN}/android-chrome-512x512.png`,
+      sameAs: [
+        "https://github.com/Solvro",
+        "https://www.facebook.com/knsolvro",
+        "https://solvro.pl",
+      ],
+    },
+    {
+      "@type": "WebSite",
+      "@id": `${SITE_ORIGIN}/#website`,
+      url: SITE_ORIGIN,
+      name: SITE_TITLE,
+      description: SITE_DESCRIPTION,
+      inLanguage: "pl-PL",
+      publisher: { "@id": ORGANIZATION_ID },
+    },
+    {
+      "@type": "WebApplication",
+      "@id": APPLICATION_ID,
+      name: "Planer Solvro",
+      url: SITE_ORIGIN,
+      description: SITE_DESCRIPTION,
+      applicationCategory: "EducationalApplication",
+      operatingSystem: "Web",
+      inLanguage: "pl-PL",
+      browserRequirements: "Wymaga JavaScript.",
+      screenshot: `${SITE_ORIGIN}/og_image.png`,
+      publisher: { "@id": ORGANIZATION_ID },
+      isAccessibleForFree: true,
+      offers: {
+        "@type": "Offer",
+        price: "0",
+        priceCurrency: "PLN",
+      },
+      featureList: [
+        "Układanie planu zajęć na Politechnice Wrocławskiej",
+        "Wykrywanie kolizji między grupami zajęciowymi",
+        "Aktualne dane o kursach i grupach z USOS",
+        "Udostępnianie gotowego planu zajęć",
+      ],
+    },
+    {
+      "@type": "FAQPage",
+      "@id": `${SITE_ORIGIN}/#faq`,
+      mainEntity: [
+        {
+          "@type": "Question",
+          name: "Czy Planer zapisuje mnie na zajęcia?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "Nie. Planer służy wyłącznie do ułożenia i sprawdzenia planu zajęć przed zapisami. Samych zapisów dokonujesz samodzielnie w systemie USOS.",
+          },
+        },
+        {
+          "@type": "Question",
+          name: "Czy korzystanie z Planera jest darmowe?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "Tak. Planer jest w pełni darmowy i rozwijany jako projekt open source przez Koło Naukowe Solvro z Politechniki Wrocławskiej.",
+          },
+        },
+        {
+          "@type": "Question",
+          name: "Skąd Planer bierze dane o kursach i grupach?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "Dane o zajęciach pochodzą z systemu USOS Politechniki Wrocławskiej, która pozostaje ich prawnym właścicielem.",
+          },
+        },
+        {
+          "@type": "Question",
+          name: "Czy muszę mieć konto, żeby ułożyć plan?",
+          acceptedAnswer: {
+            "@type": "Answer",
+            text: "Nie. Plan możesz ułożyć bez logowania. Zalogowanie się pozwala zapisać plany na koncie i mieć do nich dostęp z innych urządzeń.",
+          },
+        },
+      ],
+    },
+  ],
+};
+
+export function StructuredData() {
+  return (
+    <script
+      type="application/ld+json"
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(structuredData).replaceAll(
+          "<",
+          String.raw`\u003c`,
+        ),
+      }}
+    />
+  );
+}

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,6 @@
+export const SITE_ORIGIN = "https://planer.solvro.pl";
+
+export const SITE_TITLE = "Planer - utwórz swój plan zajęć na PWR!";
+
+export const SITE_DESCRIPTION =
+  "Planer to strona stworzona z myślą o studentach PWR, którzy pragną w prosty i intuicyjny sposób zarządzać swoimi zapisami na kursy (za darmo!).";


### PR DESCRIPTION
## Why

Google reports "Crawled — currently not indexed" for the site. Nothing is technically blocking indexing (robots.txt allows, `<meta robots>` is `index, follow`, the canonical is present, and the SSR HTML already contains the full page content), so this is a page-quality judgement rather than a configuration error. These are the technical defects found while investigating. They are hygiene fixes — they do not, on their own, address the root cause, which is that the site is a single landing page with three URLs in its sitemap.

## What changed

**Heading hierarchy.** `AnimatedTitle` rendered a `motion.h1`, so the homepage shipped four `h1` elements. The small eyebrow labels above each section ("problem", "rozwiązanie", "autorzy") were marked up as `h2`, inverting the hierarchy. Section titles are now `h2` and the eyebrows are plain paragraphs. `topwr-section` had the same inversion (`h2` eyebrow above an `h3` title) and was corrected the same way. The homepage now renders exactly one `h1`.

**JSON-LD.** The site emitted no structured data at all. Adds an `@graph` with `Organization`, `WebSite`, `WebApplication` and `FAQPage` to the homepage, following the approach in the Next.js JSON-LD guide: a native `<script type="application/ld+json">` rather than `next/script`, with `<` escaped to `<`.

**Sitemap.** `lastModified: new Date()` was evaluated per request, which forced the route to be server-rendered on demand and emitted a `lastmod` of "now" on every fetch — a signal crawlers learn to ignore. It is now a fixed date, and the build output confirms the route moved from `ƒ (Dynamic)` to `○ (Static)`.

**Canonical consistency.** The canonical resolved to `https://planer.solvro.pl` (no trailing slash) while the sitemap and `og:url` used `https://planer.solvro.pl/`. All three now use the same origin.

**`twitter:description`** was set to the site URL instead of the site description.

Shared title/description/origin values are extracted into `src/lib/site.ts`, which the layout, sitemap, robots and JSON-LD now share.

## Note on a non-issue

I initially suspected the homepage's `cache-control: private, no-cache, no-store` header was hurting crawl budget. The build output disproves it: `/` is already partially prerendered with a static shell. That header is Next's standard response for a PPR resume and is required, because `getCachedSession` sits in the tree — overriding it would risk serving one user's authenticated HTML to another. No change made.

## Not addressed

The actual traffic problem is content depth. Three URLs, two of which are app/login pages without unique content, is a classic "crawled, not indexed" profile. The USOS data could back genuinely useful indexable pages (per faculty, per registration, per course, per lecturer) plus an FAQ and guides. That is a separate, larger piece of work.
