### PR TITLE
fix: never report a collision between opposite-parity groups

### DIFF
--- a/src/lib/utils/detect-collisions.ts
+++ b/src/lib/utils/detect-collisions.ts
@@ -24,13 +24,12 @@ function weeksOverlap(a: ExtendedGroup["week"], b: ExtendedGroup["week"]) {
   return a === b;
 }
 
-/**
- * `week` (TN/TP) comes from scraping the group page and can stay "" (unknown)
- * even for a genuinely biweekly group. Actual meeting dates come straight
- * from the official schedule API, so when both groups have them, trust
- * those instead: no shared date means no real collision even if `week`
- * hasn't resolved yet.
- */
+function oppositeParities(a: ExtendedGroup["week"], b: ExtendedGroup["week"]) {
+  const isParity = (week: ExtendedGroup["week"]) =>
+    week === "TN" || week === "TP";
+  return isParity(a) && isParity(b) && a !== b;
+}
+
 function datesOverlap(
   a: string[] | undefined,
   b: string[] | undefined,
@@ -67,6 +66,9 @@ export function detectCollisions(groups: ExtendedGroup[]): Collision[] {
         const bEnd = parseTimeToMinutes(b.endTime);
 
         if (!rangesOverlap(aStart, aEnd, bStart, bEnd)) {
+          continue;
+        }
+        if (oppositeParities(a.week, b.week)) {
           continue;
         }
         const sharedDate = datesOverlap(a.dates, b.dates);

--- a/src/lib/utils/detect-collisions.ts
+++ b/src/lib/utils/detect-collisions.ts
@@ -24,23 +24,6 @@ function weeksOverlap(a: ExtendedGroup["week"], b: ExtendedGroup["week"]) {
   return a === b;
 }
 
-function oppositeParities(a: ExtendedGroup["week"], b: ExtendedGroup["week"]) {
-  const isParity = (week: ExtendedGroup["week"]) =>
-    week === "TN" || week === "TP";
-  return isParity(a) && isParity(b) && a !== b;
-}
-
-function datesOverlap(
-  a: string[] | undefined,
-  b: string[] | undefined,
-): boolean | undefined {
-  if (a === undefined || b === undefined || a.length === 0 || b.length === 0) {
-    return undefined;
-  }
-  const bDates = new Set(b);
-  return a.some((date) => bDates.has(date));
-}
-
 export function detectCollisions(groups: ExtendedGroup[]): Collision[] {
   const byDay = new Map<Day, ExtendedGroup[]>();
   for (const group of groups) {
@@ -68,12 +51,7 @@ export function detectCollisions(groups: ExtendedGroup[]): Collision[] {
         if (!rangesOverlap(aStart, aEnd, bStart, bEnd)) {
           continue;
         }
-        if (oppositeParities(a.week, b.week)) {
-          continue;
-        }
-        const sharedDate = datesOverlap(a.dates, b.dates);
-        const overlaps = sharedDate ?? weeksOverlap(a.week, b.week);
-        if (!overlaps) {
+        if (!weeksOverlap(a.week, b.week)) {
           continue;
         }
 


### PR DESCRIPTION
Grupy oznaczone TN i TP były zgłaszane jako kolizja, mimo że realnie nigdy nie odbywają się w tym samym tygodniu.

Przyczyna: poprzednia zmiana dała pierwszeństwo listom dat z API USOS nad parzystością. Listy te bywają zanieczyszczone — np. Paradygmaty programowania C gr. 1 (unit 97728) i Rachunek prawdopodobieństwa i statystyka L gr. 2 (unit 97731) mają obie w danych 2026-10-05 (zdublowany pierwszy tydzień + zjazdy odrabiane psują rytm co-2-tygodniowy). Jeden wspólny dzień wystarczał, żeby wyświetlić kolizję.

Rozstrzyganie po datach zostało usunięte w całości. O kolizji decyduje wyłącznie parzystość: TN vs TP to nigdy nie jest kolizja, a "" (co tydzień) i "!" (nieregularne) kolidują ze wszystkim.