### PR TITLE
fix: make contributors list wrap responsively and hide dependabot

### DIFF
--- a/src/components/magicui/avatars.tsx
+++ b/src/components/magicui/avatars.tsx
@@ -23,7 +23,12 @@ interface AvatarCirclesProps {
 
 export function AvatarCircles({ className, contributors }: AvatarCirclesProps) {
   return (
-    <div className={cn("z-10 flex -space-x-4 rtl:space-x-reverse", className)}>
+    <div
+      className={cn(
+        "z-10 flex flex-wrap justify-center -space-x-4 gap-y-2 rtl:space-x-reverse",
+        className,
+      )}
+    >
       {contributors.map((contributor, index) => (
         <Tooltip key={contributor.id}>
           <TooltipTrigger

--- a/src/lib/utils/get-github-stats.ts
+++ b/src/lib/utils/get-github-stats.ts
@@ -50,8 +50,11 @@ export const fetchGithubStats = async () => {
       id: number;
       contributions: number;
     }[];
-    contributorsCount = data.length;
-    for (const contributor of data) {
+    const filteredData = data.filter(
+      (contributor) => !contributor.login.includes("dependabot"),
+    );
+    contributorsCount = filteredData.length;
+    for (const contributor of filteredData) {
       contributors.push({
         name: contributor.login,
         avatar: contributor.avatar_url,


### PR DESCRIPTION
## Summary
- Avatar list on the homepage now wraps onto additional lines instead of overflowing/shrinking on narrow screens
- Dependabot is excluded from the contributors list and count