### PR TITLE
fix: restore group occupancy scraping after USOS markup change

### DIFF
--- a/src/actions/v2/get-group-spots.ts
+++ b/src/actions/v2/get-group-spots.ts
@@ -23,7 +23,7 @@ function buildGroupPageUrl(unitId: string, groupNumber: string): string {
 }
 
 function findRow($: cheerio.CheerioAPI, label: string) {
-  return $("div#layout-c22")
+  return $("#layout-main-content")
     .find("table")
     .find("tbody")
     .children()

--- a/src/app/(homepage)/_components/navbar.tsx
+++ b/src/app/(homepage)/_components/navbar.tsx
@@ -107,7 +107,10 @@ export function Navbar() {
               variant="ghost"
               className="hover:bg-blue-200/40 dark:hover:bg-white/5"
               render={
-                <Link href="https://solvro.pwr.edu.pl/contact/" target="_blank">
+                <Link
+                  href="https://solvro.pwr.edu.pl/pl/contact/"
+                  target="_blank"
+                >
                   Kontakt
                 </Link>
               }
@@ -155,7 +158,9 @@ export function Navbar() {
                   </Link>
                 </li>
                 <li className="p-2">
-                  <Link href="https://solvro.pwr.edu.pl/contact/">Kontakt</Link>
+                  <Link href="https://solvro.pwr.edu.pl/pl/contact/">
+                    Kontakt
+                  </Link>
                 </li>
                 <li className="p-2">
                   <button onClick={openDialog}>Zgłoś błąd</button>

--- a/src/app/(homepage)/page.tsx
+++ b/src/app/(homepage)/page.tsx
@@ -10,7 +10,7 @@ import { BorderBeam } from "@/components/magicui/border-beam";
 import { StructuredData } from "@/components/structured-data";
 import { Button } from "@/components/ui/button";
 import { getCachedAlerts } from "@/lib/get-cached-alerts";
-import { getCachedSession } from "@/lib/get-session";
+import { getSession } from "@/lib/get-session";
 
 import HeroImageDark from "../../../public/assets/planer-dark.png";
 import HeroImageLight from "../../../public/assets/planer-light.png";
@@ -21,7 +21,7 @@ import { ToPWrSection } from "./_components/topwr-section";
 import { TrustedSection } from "./_components/trusted-section";
 
 async function JoinUsBlock() {
-  const session = await getCachedSession();
+  const session = await getSession();
 
   if (session == null) {
     return (

--- a/src/app/plans/_components/plans-topbar.tsx
+++ b/src/app/plans/_components/plans-topbar.tsx
@@ -6,7 +6,7 @@ import { TOPBAR_SLOT_ID } from "@/components/topbar-portal";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { UserButton } from "@/components/user-button";
-import { getCachedSession } from "@/lib/get-session";
+import { getSession } from "@/lib/get-session";
 
 import { FeedbackButton } from "./feedback-button";
 import { SidebarTriggerButton } from "./sidebar-trigger-button";
@@ -65,7 +65,7 @@ export function PlansTopbar() {
 }
 
 async function UserProfile() {
-  const session = await getCachedSession();
+  const session = await getSession();
 
   if (session == null) {
     return (

--- a/src/lib/get-session.ts
+++ b/src/lib/get-session.ts
@@ -3,7 +3,6 @@ import "server-only";
 
 import { auth } from "@/lib/auth";
 
-export async function getCachedSession() {
-  "use cache: private";
+export async function getSession() {
   return auth.api.getSession({ headers: await headers() });
 }


### PR DESCRIPTION
## Summary
- USOS redesigned the group detail page and dropped the `div#layout-c22` container `get-group-spots` relied on to read "Liczba osób w grupie" / "Limit miejsc". The selector matched nothing, so every scrape silently returned `0/0` with no error (request succeeded, parsing just found an empty set) — that's why tn/tp and occupancy never showed up on the plan page. Updated the selector to `#layout-main-content`, the current container (now a `<main>`, not a `<div>`).
- Session lookup (`auth.api.getSession`) is no longer cached per request.