### PR TITLE
fix: allow two-line course titles in sidebar and class cards

### DIFF
--- a/src/app/plans/edit/[id]/_components/course-row.tsx
+++ b/src/app/plans/edit/[id]/_components/course-row.tsx
@@ -92,7 +92,9 @@ export function CourseRow({
           ))}
         </span>
         <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-medium">{course.name}</p>
+          <p className="line-clamp-2 text-sm leading-snug font-medium break-words">
+            {course.name}
+          </p>
           <p className="text-muted-foreground truncate text-xs">
             {types.join(" + ")} · {course.groups.length}{" "}
             {pluralize(course.groups.length, "grupa", "grupy", "grup")}

--- a/src/components/schedule/class-card.tsx
+++ b/src/components/schedule/class-card.tsx
@@ -80,7 +80,9 @@ export function ClassCard({
         <span>G{group.groupNumber}</span>
       </div>
       <div className="min-w-0">
-        <p className="truncate font-bold">{group.courseName}</p>
+        <p className="line-clamp-2 leading-tight font-bold break-words">
+          {group.courseName}
+        </p>
         <p className="text-muted-foreground truncate">{group.lecturer}</p>
       </div>
       <div className="mt-1 flex items-center gap-1.5">


### PR DESCRIPTION
Long course names were cut off with an ellipsis on a single line, both in the plan editor sidebar and on the class cards in the schedule. They now wrap to at most two lines (`line-clamp-2`) before being truncated.